### PR TITLE
[#7] feat(api): Wizard 단계별 답변 저장/조회 API 구현

### DIFF
--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/WizardController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/WizardController.java
@@ -1,0 +1,111 @@
+package com.vibe.bizplan.bizplan_be.api;
+
+import com.vibe.bizplan.bizplan_be.domain.service.WizardService;
+import com.vibe.bizplan.bizplan_be.dto.request.SaveWizardAnswersRequest;
+import com.vibe.bizplan.bizplan_be.dto.response.WizardAnswersResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * Wizard REST API 컨트롤러.
+ * Wizard 단계별 답변 저장 및 조회 API를 제공한다.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/projects/{projectId}/wizard")
+@RequiredArgsConstructor
+@Tag(name = "Wizard", description = "Wizard 단계별 답변 관리 API")
+public class WizardController {
+
+    private final WizardService wizardService;
+
+    /**
+     * Wizard 답변 저장 (Upsert).
+     * 특정 단계의 답변을 저장하거나 업데이트한다.
+     * 기존 답변은 유지되며 해당 단계의 답변만 병합된다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param request 답변 저장 요청
+     * @return 업데이트된 전체 답변
+     */
+    @PostMapping("/steps")
+    @Operation(summary = "답변 저장", description = "Wizard 특정 단계의 답변을 저장합니다. 기존 답변과 병합됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공",
+                    content = @Content(schema = @Schema(implementation = WizardAnswersResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public ResponseEntity<WizardAnswersResponse> saveAnswers(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Valid @RequestBody SaveWizardAnswersRequest request
+    ) {
+        log.info("POST /projects/{}/wizard/steps - stepId={}", projectId, request.stepId());
+        
+        WizardAnswersResponse response = wizardService.saveAnswers(projectId, request);
+        
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Wizard 전체 답변 조회.
+     * 프로젝트에 저장된 모든 단계의 답변을 조회한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 전체 답변 데이터
+     */
+    @GetMapping("/answers")
+    @Operation(summary = "전체 답변 조회", description = "프로젝트에 저장된 모든 Wizard 답변을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = WizardAnswersResponse.class))),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public ResponseEntity<WizardAnswersResponse> getAnswers(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId
+    ) {
+        log.info("GET /projects/{}/wizard/answers", projectId);
+        
+        WizardAnswersResponse response = wizardService.getAnswers(projectId);
+        
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 특정 단계 답변 조회.
+     * 지정된 단계의 답변만 조회한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param stepId 단계 ID
+     * @return 해당 단계의 답변
+     */
+    @GetMapping("/steps/{stepId}")
+    @Operation(summary = "단계별 답변 조회", description = "특정 단계의 답변만 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public ResponseEntity<Map<String, Object>> getStepAnswers(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Parameter(description = "단계 ID") @PathVariable String stepId
+    ) {
+        log.info("GET /projects/{}/wizard/steps/{}", projectId, stepId);
+        
+        Map<String, Object> answers = wizardService.getStepAnswers(projectId, stepId);
+        
+        return ResponseEntity.ok(answers);
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/entity/Project.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/entity/Project.java
@@ -47,6 +47,10 @@ public class Project {
     @Column(name = "user_id", length = 36)
     private String userId;
 
+    /** Wizard 단계별 답변 데이터 (JSON 문자열) */
+    @Column(name = "wizard_answers", columnDefinition = "TEXT")
+    private String wizardAnswers;
+
     /** 생성일시 */
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -90,6 +94,15 @@ public class Project {
      */
     public void changeStatus(ProjectStatus status) {
         this.status = status;
+    }
+
+    /**
+     * Wizard 답변 업데이트.
+     *
+     * @param wizardAnswers JSON 형태의 답변 문자열
+     */
+    public void updateWizardAnswers(String wizardAnswers) {
+        this.wizardAnswers = wizardAnswers;
     }
 }
 

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/WizardService.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/WizardService.java
@@ -1,0 +1,137 @@
+package com.vibe.bizplan.bizplan_be.domain.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vibe.bizplan.bizplan_be.domain.entity.Project;
+import com.vibe.bizplan.bizplan_be.domain.model.ProjectStatus;
+import com.vibe.bizplan.bizplan_be.dto.request.SaveWizardAnswersRequest;
+import com.vibe.bizplan.bizplan_be.dto.response.WizardAnswersResponse;
+import com.vibe.bizplan.bizplan_be.infrastructure.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Wizard 서비스.
+ * Wizard 단계별 답변 저장 및 조회 로직을 처리한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WizardService {
+
+    private final ProjectRepository projectRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Wizard 답변 저장 (Upsert).
+     * 기존 답변에 새로운 답변을 병합하여 저장한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param request 답변 저장 요청
+     * @return 업데이트된 전체 답변
+     */
+    @Transactional
+    public WizardAnswersResponse saveAnswers(String projectId, SaveWizardAnswersRequest request) {
+        log.info("Wizard 답변 저장: projectId={}, stepId={}", projectId, request.stepId());
+        
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다: " + projectId));
+        
+        // 기존 답변 파싱
+        Map<String, Object> existingAnswers = parseAnswers(project.getWizardAnswers());
+        
+        // 새 답변 병합 (해당 stepId의 답변만 업데이트)
+        existingAnswers.put(request.stepId(), request.answers());
+        
+        // JSON으로 변환하여 저장
+        String updatedJson = toJson(existingAnswers);
+        project.updateWizardAnswers(updatedJson);
+        
+        // 프로젝트 상태 업데이트 (DRAFT → IN_PROGRESS)
+        if (project.getStatus() == ProjectStatus.DRAFT) {
+            project.changeStatus(ProjectStatus.IN_PROGRESS);
+            log.debug("프로젝트 상태 변경: DRAFT → IN_PROGRESS");
+        }
+        
+        projectRepository.save(project);
+        log.info("Wizard 답변 저장 완료: projectId={}, totalSteps={}", projectId, existingAnswers.size());
+        
+        return WizardAnswersResponse.of(projectId, existingAnswers);
+    }
+
+    /**
+     * Wizard 전체 답변 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 전체 답변 데이터
+     */
+    @Transactional(readOnly = true)
+    public WizardAnswersResponse getAnswers(String projectId) {
+        log.debug("Wizard 답변 조회: projectId={}", projectId);
+        
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다: " + projectId));
+        
+        Map<String, Object> answers = parseAnswers(project.getWizardAnswers());
+        
+        return WizardAnswersResponse.of(projectId, answers);
+    }
+
+    /**
+     * 특정 단계의 답변만 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @param stepId 단계 ID
+     * @return 해당 단계의 답변 (없으면 빈 Map)
+     */
+    @Transactional(readOnly = true)
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getStepAnswers(String projectId, String stepId) {
+        log.debug("특정 단계 답변 조회: projectId={}, stepId={}", projectId, stepId);
+        
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다: " + projectId));
+        
+        Map<String, Object> allAnswers = parseAnswers(project.getWizardAnswers());
+        Object stepAnswers = allAnswers.get(stepId);
+        
+        if (stepAnswers instanceof Map) {
+            return (Map<String, Object>) stepAnswers;
+        }
+        return new HashMap<>();
+    }
+
+    /**
+     * JSON 문자열을 Map으로 파싱.
+     */
+    private Map<String, Object> parseAnswers(String json) {
+        if (json == null || json.isBlank()) {
+            return new HashMap<>();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+        } catch (JsonProcessingException e) {
+            log.error("JSON 파싱 실패: {}", e.getMessage());
+            return new HashMap<>();
+        }
+    }
+
+    /**
+     * Map을 JSON 문자열로 변환.
+     */
+    private String toJson(Map<String, Object> data) {
+        try {
+            return objectMapper.writeValueAsString(data);
+        } catch (JsonProcessingException e) {
+            log.error("JSON 변환 실패: {}", e.getMessage());
+            throw new RuntimeException("답변 데이터 변환에 실패했습니다", e);
+        }
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/SaveWizardAnswersRequest.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/SaveWizardAnswersRequest.java
@@ -1,0 +1,23 @@
+package com.vibe.bizplan.bizplan_be.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Map;
+
+/**
+ * Wizard 단계별 답변 저장 요청 DTO.
+ * 특정 단계의 답변을 저장하거나 업데이트한다.
+ */
+public record SaveWizardAnswersRequest(
+        
+        /** 단계 ID (예: "step1", "problem_definition") */
+        @NotBlank(message = "단계 ID는 필수입니다")
+        String stepId,
+        
+        /** 해당 단계의 답변 데이터 (Key-Value 형태) */
+        @NotNull(message = "답변 데이터는 필수입니다")
+        Map<String, Object> answers
+) {
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/ProjectResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/ProjectResponse.java
@@ -1,9 +1,14 @@
 package com.vibe.bizplan.bizplan_be.dto.response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vibe.bizplan.bizplan_be.domain.entity.Project;
 import com.vibe.bizplan.bizplan_be.domain.model.ProjectStatus;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * 프로젝트 응답 DTO.
@@ -23,12 +28,17 @@ public record ProjectResponse(
         /** 프로젝트 상태 */
         ProjectStatus status,
         
+        /** Wizard 답변 데이터 */
+        Map<String, Object> wizardAnswers,
+        
         /** 생성일시 */
         LocalDateTime createdAt,
         
         /** 수정일시 */
         LocalDateTime updatedAt
 ) {
+    
+    private static final ObjectMapper objectMapper = new ObjectMapper();
     
     /**
      * Project 엔티티로부터 응답 DTO 생성.
@@ -37,14 +47,30 @@ public record ProjectResponse(
      * @return 프로젝트 응답 DTO
      */
     public static ProjectResponse from(Project project) {
+        Map<String, Object> answers = parseWizardAnswers(project.getWizardAnswers());
         return new ProjectResponse(
                 project.getId(),
                 project.getTemplateCode().name(),
                 project.getTitle(),
                 project.getStatus(),
+                answers,
                 project.getCreatedAt(),
                 project.getUpdatedAt()
         );
+    }
+    
+    /**
+     * JSON 문자열을 Map으로 파싱.
+     */
+    private static Map<String, Object> parseWizardAnswers(String json) {
+        if (json == null || json.isBlank()) {
+            return Collections.emptyMap();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+        } catch (JsonProcessingException e) {
+            return Collections.emptyMap();
+        }
     }
 }
 

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/WizardAnswersResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/WizardAnswersResponse.java
@@ -1,0 +1,38 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import java.util.Map;
+
+/**
+ * Wizard 답변 응답 DTO.
+ * 저장된 Wizard 답변 데이터를 반환한다.
+ */
+public record WizardAnswersResponse(
+        
+        /** 프로젝트 ID */
+        String projectId,
+        
+        /** 전체 Wizard 답변 데이터 (단계별 Key-Value) */
+        Map<String, Object> answers,
+        
+        /** 완료된 단계 수 */
+        int completedSteps,
+        
+        /** 전체 단계 수 */
+        int totalSteps
+) {
+    
+    /**
+     * 정적 팩토리 메서드.
+     *
+     * @param projectId 프로젝트 ID
+     * @param answers 답변 데이터
+     * @return WizardAnswersResponse
+     */
+    public static WizardAnswersResponse of(String projectId, Map<String, Object> answers) {
+        int completedSteps = answers != null ? answers.size() : 0;
+        // TODO: 템플릿별 전체 단계 수 조회 로직 추가
+        int totalSteps = 10; // 임시 기본값
+        return new WizardAnswersResponse(projectId, answers, completedSteps, totalSteps);
+    }
+}
+

--- a/src/main/resources/db/migration/V2__add_wizard_answers_column.sql
+++ b/src/main/resources/db/migration/V2__add_wizard_answers_column.sql
@@ -1,0 +1,11 @@
+-- ==========================================
+-- V2: Add wizard_answers column to projects table
+-- Wizard 단계별 답변 저장을 위한 JSON 컬럼 추가
+-- ==========================================
+
+ALTER TABLE projects ADD COLUMN wizard_answers TEXT;
+
+-- 컬럼 설명 (MySQL에서는 주석으로 대체)
+-- wizard_answers: JSON 형태로 Wizard 각 단계의 답변을 Key-Value로 저장
+-- 예: {"step1": {"question1": "답변1"}, "step2": {"question2": "답변2"}}
+


### PR DESCRIPTION
## 개요
Issue #7 해결: Wizard 단계별 답변 저장/조회 API 구현

## 변경 사항

### 🔌 구현된 API 엔드포인트
| Method | Endpoint | 설명 |
|--------|----------|------|
| `POST` | `/projects/{id}/wizard/steps` | 답변 저장 (Upsert) |
| `GET` | `/projects/{id}/wizard/answers` | 전체 답변 조회 |
| `GET` | `/projects/{id}/wizard/steps/{stepId}` | 단계별 답변 조회 |

### 📁 변경된 파일
- `V2__add_wizard_answers_column.sql`: wizard_answers 컬럼 추가
- `Project.java`: wizardAnswers 필드 및 업데이트 메서드 추가
- `WizardService.java`: 답변 병합(Merge) 로직
- `WizardController.java`: REST API 엔드포인트
- `SaveWizardAnswersRequest.java`: 요청 DTO
- `WizardAnswersResponse.java`: 응답 DTO
- `ProjectResponse.java`: wizardAnswers 필드 추가

### 주요 기능
- **Upsert 방식**: 기존 답변을 유지하면서 새 답변만 병합
- **상태 자동 변경**: DRAFT → IN_PROGRESS (첫 답변 저장 시)
- **JSON 저장**: wizard_answers를 TEXT(JSON) 형태로 저장

## 테스트
- [x] `./gradlew build` 빌드 성공
- [x] `./gradlew test` 테스트 통과

## 관련 이슈
Closes #7