### PR TITLE
[#14] feat(security): 데이터 암호화 및 보안 구성 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	
 	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -43,6 +44,7 @@ dependencies {
 	
 	// Testing
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/vibe/bizplan/bizplan_be/config/SecurityConfig.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/config/SecurityConfig.java
@@ -1,0 +1,72 @@
+package com.vibe.bizplan.bizplan_be.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Spring Security 설정.
+ * MVP 단계에서는 인증 없이 API를 허용하되, 향후 확장을 위한 기본 구조를 설정한다.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    /**
+     * BCrypt 기반 PasswordEncoder 빈.
+     * 사용자 비밀번호를 안전하게 해시화하는 데 사용한다.
+     * 
+     * @return BCryptPasswordEncoder 인스턴스
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * Security Filter Chain 설정.
+     * MVP 단계: 모든 API 허용, CSRF 비활성화 (REST API용).
+     * 
+     * @param http HttpSecurity 설정 객체
+     * @return 설정된 SecurityFilterChain
+     * @throws Exception 설정 오류 시
+     */
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            // CSRF 비활성화 (REST API는 stateless이므로 불필요)
+            .csrf(AbstractHttpConfigurer::disable)
+            
+            // 세션 관리: Stateless (JWT 등 토큰 기반 인증을 위해)
+            .sessionManagement(session -> 
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            
+            // H2 Console 허용을 위한 Frame Options 설정
+            .headers(headers -> 
+                headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
+            )
+            
+            // MVP: 모든 요청 허용 (향후 인증 적용 예정)
+            .authorizeHttpRequests(auth -> auth
+                // Swagger UI 및 API 문서
+                .requestMatchers("/swagger-ui/**", "/api-docs/**", "/swagger-ui.html").permitAll()
+                // H2 Console (개발용)
+                .requestMatchers("/h2-console/**").permitAll()
+                // 헬스체크
+                .requestMatchers("/actuator/**").permitAll()
+                // MVP: 모든 API 허용
+                .anyRequest().permitAll()
+            );
+        
+        return http.build();
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/entity/Project.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/entity/Project.java
@@ -2,6 +2,7 @@ package com.vibe.bizplan.bizplan_be.domain.entity;
 
 import com.vibe.bizplan.bizplan_be.domain.model.ProjectStatus;
 import com.vibe.bizplan.bizplan_be.domain.model.TemplateCode;
+import com.vibe.bizplan.bizplan_be.infrastructure.security.EncryptedStringConverter;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -47,8 +48,9 @@ public class Project {
     @Column(name = "user_id", length = 36)
     private String userId;
 
-    /** Wizard 단계별 답변 데이터 (JSON 문자열) */
+    /** Wizard 단계별 답변 데이터 (JSON 문자열, AES-256 암호화) */
     @Column(name = "wizard_answers", columnDefinition = "TEXT")
+    @Convert(converter = EncryptedStringConverter.class)
     private String wizardAnswers;
 
     /** 생성일시 */

--- a/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/security/AesEncryptionUtil.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/security/AesEncryptionUtil.java
@@ -1,0 +1,131 @@
+package com.vibe.bizplan.bizplan_be.infrastructure.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * AES-256-GCM 암호화 유틸리티.
+ * 민감한 데이터의 암호화/복호화를 담당한다.
+ * GCM 모드는 기밀성과 무결성을 동시에 보장한다.
+ */
+@Slf4j
+@Component
+public class AesEncryptionUtil {
+
+    private static final String ALGORITHM = "AES";
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12;  // 96 bits (권장)
+    private static final int GCM_TAG_LENGTH = 128; // 128 bits
+
+    private final SecretKeySpec secretKey;
+
+    /**
+     * 생성자: 환경변수에서 암호화 키를 로드한다.
+     * 키는 Base64 인코딩된 32바이트(256비트) 문자열이어야 한다.
+     * 
+     * @param encryptionKey Base64 인코딩된 AES-256 키
+     */
+    public AesEncryptionUtil(
+            @Value("${app.security.encryption-key:#{null}}") String encryptionKey
+    ) {
+        if (encryptionKey == null || encryptionKey.isBlank()) {
+            // MVP: 기본 키 사용 (운영 환경에서는 반드시 환경변수로 설정해야 함)
+            log.warn("암호화 키가 설정되지 않았습니다. 기본 키를 사용합니다. 운영 환경에서는 반드시 app.security.encryption-key를 설정하세요!");
+            encryptionKey = "Yml6cGxhbl9lbmNyeXB0aW9uX2tleV8zMmJ5dGVzISE="; // 32 bytes base64
+        }
+        
+        byte[] keyBytes = Base64.getDecoder().decode(encryptionKey);
+        if (keyBytes.length != 32) {
+            throw new IllegalArgumentException("암호화 키는 32바이트(256비트)여야 합니다. 현재: " + keyBytes.length + "바이트");
+        }
+        this.secretKey = new SecretKeySpec(keyBytes, ALGORITHM);
+        log.info("AES-256-GCM 암호화 유틸리티 초기화 완료");
+    }
+
+    /**
+     * 문자열을 AES-256-GCM으로 암호화한다.
+     * IV는 암호문 앞에 붙여서 반환한다 (IV + 암호문).
+     * 
+     * @param plainText 암호화할 평문
+     * @return Base64 인코딩된 암호문 (IV 포함)
+     */
+    public String encrypt(String plainText) {
+        if (plainText == null || plainText.isEmpty()) {
+            return plainText;
+        }
+        
+        try {
+            // 랜덤 IV 생성
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            SecureRandom secureRandom = new SecureRandom();
+            secureRandom.nextBytes(iv);
+            
+            // Cipher 초기화
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            GCMParameterSpec gcmSpec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, gcmSpec);
+            
+            // 암호화
+            byte[] encrypted = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+            
+            // IV + 암호문 결합
+            byte[] combined = new byte[iv.length + encrypted.length];
+            System.arraycopy(iv, 0, combined, 0, iv.length);
+            System.arraycopy(encrypted, 0, combined, iv.length, encrypted.length);
+            
+            return Base64.getEncoder().encodeToString(combined);
+            
+        } catch (Exception e) {
+            log.error("암호화 실패", e);
+            throw new RuntimeException("데이터 암호화에 실패했습니다", e);
+        }
+    }
+
+    /**
+     * AES-256-GCM으로 암호화된 문자열을 복호화한다.
+     * 
+     * @param encryptedText Base64 인코딩된 암호문 (IV 포함)
+     * @return 복호화된 평문
+     */
+    public String decrypt(String encryptedText) {
+        if (encryptedText == null || encryptedText.isEmpty()) {
+            return encryptedText;
+        }
+        
+        try {
+            // Base64 디코딩
+            byte[] combined = Base64.getDecoder().decode(encryptedText);
+            
+            // IV 추출
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            System.arraycopy(combined, 0, iv, 0, iv.length);
+            
+            // 암호문 추출
+            byte[] encrypted = new byte[combined.length - iv.length];
+            System.arraycopy(combined, iv.length, encrypted, 0, encrypted.length);
+            
+            // Cipher 초기화
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            GCMParameterSpec gcmSpec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmSpec);
+            
+            // 복호화
+            byte[] decrypted = cipher.doFinal(encrypted);
+            
+            return new String(decrypted, StandardCharsets.UTF_8);
+            
+        } catch (Exception e) {
+            log.error("복호화 실패", e);
+            throw new RuntimeException("데이터 복호화에 실패했습니다", e);
+        }
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/security/EncryptedStringConverter.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/security/EncryptedStringConverter.java
@@ -1,0 +1,78 @@
+package com.vibe.bizplan.bizplan_be.infrastructure.security;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * JPA AttributeConverter: 문자열 필드의 자동 암호화/복호화.
+ * Entity 필드에 @Convert(converter = EncryptedStringConverter.class)를 적용하면
+ * DB 저장 시 자동으로 암호화되고, 조회 시 자동으로 복호화된다.
+ */
+@Slf4j
+@Component
+@Converter
+public class EncryptedStringConverter implements AttributeConverter<String, String> {
+
+    private final AesEncryptionUtil aesEncryptionUtil;
+
+    /**
+     * Spring DI를 통해 암호화 유틸리티를 주입받는다.
+     * 
+     * @param aesEncryptionUtil AES 암호화 유틸리티
+     */
+    public EncryptedStringConverter(AesEncryptionUtil aesEncryptionUtil) {
+        this.aesEncryptionUtil = aesEncryptionUtil;
+        log.info("EncryptedStringConverter 초기화 완료");
+    }
+
+    /**
+     * Entity → DB: 평문을 암호화하여 저장한다.
+     * 
+     * @param attribute Entity의 평문 값
+     * @return DB에 저장할 암호문
+     */
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return attribute;
+        }
+        
+        try {
+            String encrypted = aesEncryptionUtil.encrypt(attribute);
+            log.debug("데이터 암호화 완료: 원본 길이={}, 암호문 길이={}", 
+                    attribute.length(), encrypted.length());
+            return encrypted;
+        } catch (Exception e) {
+            log.error("DB 저장 시 암호화 실패", e);
+            throw new RuntimeException("데이터 암호화에 실패했습니다", e);
+        }
+    }
+
+    /**
+     * DB → Entity: 암호문을 복호화하여 반환한다.
+     * 
+     * @param dbData DB에서 읽은 암호문
+     * @return Entity에 설정할 평문
+     */
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isEmpty()) {
+            return dbData;
+        }
+        
+        try {
+            String decrypted = aesEncryptionUtil.decrypt(dbData);
+            log.debug("데이터 복호화 완료: 암호문 길이={}, 원본 길이={}", 
+                    dbData.length(), decrypted.length());
+            return decrypted;
+        } catch (Exception e) {
+            log.error("DB 조회 시 복호화 실패", e);
+            // 복호화 실패 시 원본 반환 (마이그레이션 중 기존 평문 데이터 처리)
+            log.warn("복호화 실패로 원본 데이터 반환 (평문 데이터일 수 있음)");
+            return dbData;
+        }
+    }
+}
+

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -3,7 +3,7 @@
 # ==========================================
 # Usage: java -jar app.jar --spring.profiles.active=mysql
 
-spring.datasource.url=jdbc:mysql://localhost:3306/bizplan?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:3306/bizplan?useSSL=true&serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=${DB_USERNAME:bizplan}
 spring.datasource.password=${DB_PASSWORD:bizplan}
@@ -16,4 +16,19 @@ spring.jpa.show-sql=false
 
 # H2 Console disabled for production
 spring.h2.console.enabled=false
+
+# ==========================================
+# Security Configuration (Production)
+# ==========================================
+# AES-256 암호화 키 (환경변수에서 로드, 필수)
+app.security.encryption-key=${ENCRYPTION_KEY}
+
+# HTTPS 설정 (운영 환경에서 활성화)
+# server.ssl.enabled=true
+# server.ssl.key-store=${SSL_KEYSTORE_PATH}
+# server.ssl.key-store-password=${SSL_KEYSTORE_PASSWORD}
+# server.ssl.key-store-type=PKCS12
+
+# HTTP → HTTPS 리다이렉트 강제 (Reverse Proxy 환경)
+# server.forward-headers-strategy=native
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,14 @@ springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.operationsSorter=method
 
 # ==========================================
+# Security Configuration
+# ==========================================
+# AES-256 암호화 키 (Base64 인코딩된 32바이트)
+# 개발환경: 기본값 사용 (운영환경에서는 환경변수로 설정 필수)
+# 운영환경: app.security.encryption-key=${ENCRYPTION_KEY}
+app.security.encryption-key=Yml6cGxhbl9lbmNyeXB0aW9uX2tleV8zMmJ5dGVzISE=
+
+# ==========================================
 # Logging
 # ==========================================
 logging.level.com.vibe.bizplan=DEBUG


### PR DESCRIPTION
## 개요
Issue #14 해결: 데이터 저장/전송 암호화 및 보안 구성

## 변경 사항

### 🔐 보안 기능
| 기능 | 설명 |
|------|------|
| BCrypt PasswordEncoder | 비밀번호 단방향 해시 (향후 인증 적용 대비) |
| AES-256-GCM 암호화 | 민감 데이터 암/복호화 |
| JPA AttributeConverter | DB 저장 시 자동 암호화 |
| Stateless 세션 | JWT 토큰 기반 인증 대비 |

### 📁 변경된 파일 (7개)
- `build.gradle`: spring-boot-starter-security 추가
- `SecurityConfig.java`: Spring Security 설정
- `AesEncryptionUtil.java`: AES-256-GCM 암호화 유틸
- `EncryptedStringConverter.java`: JPA 컨버터
- `Project.java`: wizard_answers 암호화 적용
- `application.properties`: 암호화 키 설정
- `application-mysql.properties`: 운영환경 보안 설정

### 🔒 암호화 적용 필드
- `projects.wizard_answers` - 사업계획서 답변 데이터 (AES-256 암호화)

### ⚙️ 운영환경 설정 필요
```bash
# 암호화 키 설정 (32바이트 Base64)
export ENCRYPTION_KEY=<your-secure-key>

# HTTPS 설정 (application-mysql.properties 주석 해제)
# server.ssl.enabled=true
```

## 테스트
- [x] `./gradlew build` 빌드 성공
- [x] `./gradlew test` 테스트 통과

## 관련 이슈
Closes #14