### PR TITLE
[#11] 사업계획서 PDF/HTML 내보내기 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
 	// Structured Logging (JSON)
 	implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 	
+	// Document Export (PDF)
+	implementation 'org.thymeleaf:thymeleaf:3.1.2.RELEASE'  // HTML 템플릿
+	implementation 'org.xhtmlrenderer:flying-saucer-pdf:9.1.22'  // HTML to PDF
+	
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/ExportController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/ExportController.java
@@ -1,0 +1,134 @@
+package com.vibe.bizplan.bizplan_be.api;
+
+import com.vibe.bizplan.bizplan_be.domain.model.ExportFormat;
+import com.vibe.bizplan.bizplan_be.domain.service.DocumentExportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 문서 내보내기 REST API 컨트롤러.
+ * 사업계획서를 PDF/HTML 형식으로 다운로드하는 API를 제공한다.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/projects/{projectId}")
+@RequiredArgsConstructor
+@Tag(name = "Document Export", description = "사업계획서 내보내기 API")
+public class ExportController {
+
+    private final DocumentExportService exportService;
+
+    /**
+     * 사업계획서 내보내기.
+     * 최신 버전의 문서를 지정된 형식으로 다운로드한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param format 출력 형식 (pdf, html)
+     * @return 파일 바이트 스트림
+     */
+    @GetMapping("/export")
+    @Operation(
+            summary = "사업계획서 내보내기",
+            description = "생성된 사업계획서를 PDF 또는 HTML 형식으로 다운로드합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내보내기 성공"),
+            @ApiResponse(responseCode = "400", description = "지원하지 않는 형식"),
+            @ApiResponse(responseCode = "404", description = "문서 없음")
+    })
+    public ResponseEntity<byte[]> exportDocument(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Parameter(description = "출력 형식 (pdf, html)") @RequestParam(defaultValue = "pdf") String format
+    ) {
+        log.info("GET /projects/{}/export?format={}", projectId, format);
+        
+        ExportFormat exportFormat = parseFormat(format);
+        byte[] fileContent = exportService.exportDocument(projectId, exportFormat);
+        String fileName = exportService.generateFileName(projectId, exportFormat);
+        
+        return buildFileResponse(fileContent, fileName, exportFormat);
+    }
+
+    /**
+     * 특정 버전의 문서 내보내기.
+     */
+    @GetMapping("/export/versions/{version}")
+    @Operation(
+            summary = "특정 버전 내보내기",
+            description = "지정된 버전의 사업계획서를 다운로드합니다."
+    )
+    public ResponseEntity<byte[]> exportDocumentVersion(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Parameter(description = "문서 버전") @PathVariable int version,
+            @Parameter(description = "출력 형식 (pdf, html)") @RequestParam(defaultValue = "pdf") String format
+    ) {
+        log.info("GET /projects/{}/export/versions/{}?format={}", projectId, version, format);
+        
+        ExportFormat exportFormat = parseFormat(format);
+        byte[] fileContent = exportService.exportDocumentVersion(projectId, version, exportFormat);
+        String fileName = exportService.generateFileName(projectId, exportFormat);
+        
+        return buildFileResponse(fileContent, fileName, exportFormat);
+    }
+
+    /**
+     * 지원하는 내보내기 형식 목록.
+     */
+    @GetMapping("/export/formats")
+    @Operation(
+            summary = "지원 형식 목록",
+            description = "사용 가능한 내보내기 형식을 반환합니다."
+    )
+    public ResponseEntity<?> getSupportedFormats() {
+        return ResponseEntity.ok(new Object() {
+            public final String[] formats = {"pdf", "html"};
+            public final String defaultFormat = "pdf";
+            public final String note = "HWP 형식은 향후 지원 예정입니다.";
+        });
+    }
+
+    /**
+     * 형식 문자열 파싱.
+     */
+    private ExportFormat parseFormat(String format) {
+        try {
+            return ExportFormat.valueOf(format.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn("지원하지 않는 형식: {}", format);
+            throw new IllegalArgumentException("지원하지 않는 형식입니다: " + format + ". 사용 가능: pdf, html");
+        }
+    }
+
+    /**
+     * 파일 다운로드 응답 생성.
+     */
+    private ResponseEntity<byte[]> buildFileResponse(byte[] content, String fileName, ExportFormat format) {
+        String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8)
+                .replaceAll("\\+", "%20");
+        
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType(format.getContentType()));
+        headers.setContentLength(content.length);
+        headers.set(HttpHeaders.CONTENT_DISPOSITION, 
+                "attachment; filename=\"" + encodedFileName + "\"; filename*=UTF-8''" + encodedFileName);
+        
+        log.info("파일 다운로드 응답: fileName={}, size={}KB", fileName, content.length / 1024);
+        
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(content);
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/config/ThymeleafConfig.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/config/ThymeleafConfig.java
@@ -1,0 +1,34 @@
+package com.vibe.bizplan.bizplan_be.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+/**
+ * Thymeleaf 설정.
+ * HTML 템플릿 렌더링을 위한 설정.
+ */
+@Configuration
+public class ThymeleafConfig {
+
+    @Bean
+    public TemplateEngine templateEngine() {
+        TemplateEngine templateEngine = new TemplateEngine();
+        templateEngine.setTemplateResolver(templateResolver());
+        return templateEngine;
+    }
+
+    @Bean
+    public ClassLoaderTemplateResolver templateResolver() {
+        ClassLoaderTemplateResolver resolver = new ClassLoaderTemplateResolver();
+        resolver.setPrefix("templates/export/");
+        resolver.setSuffix(".html");
+        resolver.setTemplateMode(TemplateMode.HTML);
+        resolver.setCharacterEncoding("UTF-8");
+        resolver.setCacheable(false);  // 개발 중에는 캐시 비활성화
+        return resolver;
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/model/ExportFormat.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/model/ExportFormat.java
@@ -1,0 +1,33 @@
+package com.vibe.bizplan.bizplan_be.domain.model;
+
+/**
+ * 문서 내보내기 포맷.
+ */
+public enum ExportFormat {
+    
+    /** PDF 형식 */
+    PDF("application/pdf", ".pdf"),
+    
+    /** HTML 형식 (미리보기용) */
+    HTML("text/html", ".html");
+    
+    // HWP는 라이선스 및 구현 복잡도로 인해 MVP에서는 제외
+    // HWP("application/x-hwp", ".hwp");
+    
+    private final String contentType;
+    private final String extension;
+    
+    ExportFormat(String contentType, String extension) {
+        this.contentType = contentType;
+        this.extension = extension;
+    }
+    
+    public String getContentType() {
+        return contentType;
+    }
+    
+    public String getExtension() {
+        return extension;
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/DocumentExportService.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/DocumentExportService.java
@@ -1,0 +1,151 @@
+package com.vibe.bizplan.bizplan_be.domain.service;
+
+import com.vibe.bizplan.bizplan_be.domain.entity.BusinessPlanDocument;
+import com.vibe.bizplan.bizplan_be.domain.entity.Project;
+import com.vibe.bizplan.bizplan_be.domain.model.ExportFormat;
+import com.vibe.bizplan.bizplan_be.infrastructure.repository.BusinessPlanDocumentRepository;
+import com.vibe.bizplan.bizplan_be.infrastructure.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 문서 내보내기 서비스.
+ * 사업계획서를 PDF/HTML 형식으로 변환하여 제공한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DocumentExportService {
+
+    private final ProjectRepository projectRepository;
+    private final BusinessPlanDocumentRepository documentRepository;
+    private final TemplateEngine templateEngine;
+
+    /**
+     * 사업계획서를 지정된 포맷으로 내보내기.
+     *
+     * @param projectId 프로젝트 ID
+     * @param format 출력 포맷
+     * @return 파일 바이트 배열
+     */
+    public byte[] exportDocument(String projectId, ExportFormat format) {
+        log.info("문서 내보내기 시작: projectId={}, format={}", projectId, format);
+        
+        // 프로젝트 조회
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다: " + projectId));
+        
+        // 최신 문서 조회
+        BusinessPlanDocument document = documentRepository.findFirstByProjectIdOrderByVersionDesc(projectId)
+                .orElseThrow(() -> new IllegalStateException("생성된 사업계획서가 없습니다. 먼저 문서를 생성해주세요."));
+        
+        // HTML 렌더링
+        String html = renderHtml(project, document);
+        
+        return switch (format) {
+            case PDF -> convertToPdf(html);
+            case HTML -> html.getBytes(StandardCharsets.UTF_8);
+        };
+    }
+
+    /**
+     * 특정 버전의 문서 내보내기.
+     */
+    public byte[] exportDocumentVersion(String projectId, int version, ExportFormat format) {
+        log.info("문서 내보내기: projectId={}, version={}, format={}", projectId, version, format);
+        
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다"));
+        
+        BusinessPlanDocument document = documentRepository.findByProjectIdAndVersion(projectId, version)
+                .orElseThrow(() -> new IllegalArgumentException("해당 버전의 문서를 찾을 수 없습니다: v" + version));
+        
+        String html = renderHtml(project, document);
+        
+        return switch (format) {
+            case PDF -> convertToPdf(html);
+            case HTML -> html.getBytes(StandardCharsets.UTF_8);
+        };
+    }
+
+    /**
+     * HTML 템플릿 렌더링.
+     */
+    private String renderHtml(Project project, BusinessPlanDocument document) {
+        Context context = new Context();
+        
+        // 프로젝트 정보
+        context.setVariable("projectTitle", project.getTitle() != null ? project.getTitle() : "사업계획서");
+        context.setVariable("templateName", project.getTemplateCode().getDisplayName());
+        context.setVariable("version", document.getVersion());
+        context.setVariable("createdAt", formatDateTime(document.getCreatedAt()));
+        
+        // 섹션별 내용
+        Map<String, String> sections = new HashMap<>();
+        sections.put("executiveSummary", document.getExecutiveSummary());
+        sections.put("problemDefinition", document.getProblemDefinition());
+        sections.put("solution", document.getSolution());
+        sections.put("marketAnalysis", document.getMarketAnalysis());
+        sections.put("businessModel", document.getBusinessModel());
+        sections.put("competitiveAnalysis", document.getCompetitiveAnalysis());
+        sections.put("marketingStrategy", document.getMarketingStrategy());
+        sections.put("team", document.getTeam());
+        sections.put("financialPlan", document.getFinancialPlan());
+        sections.put("milestones", document.getMilestones());
+        context.setVariable("sections", sections);
+        
+        // 메타데이터
+        context.setVariable("totalWordCount", document.getTotalWordCount());
+        
+        return templateEngine.process("business-plan-template", context);
+    }
+
+    /**
+     * HTML을 PDF로 변환.
+     */
+    private byte[] convertToPdf(String html) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            ITextRenderer renderer = new ITextRenderer();
+            renderer.setDocumentFromString(html);
+            renderer.layout();
+            renderer.createPDF(outputStream);
+            
+            log.info("PDF 생성 완료: size={}KB", outputStream.size() / 1024);
+            return outputStream.toByteArray();
+            
+        } catch (Exception e) {
+            log.error("PDF 변환 실패", e);
+            throw new RuntimeException("PDF 생성에 실패했습니다: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 파일명 생성.
+     */
+    public String generateFileName(String projectId, ExportFormat format) {
+        Project project = projectRepository.findById(projectId).orElse(null);
+        String title = project != null && project.getTitle() != null 
+                ? project.getTitle().replaceAll("[^a-zA-Z0-9가-힣]", "_")
+                : "bizplan";
+        
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        return String.format("%s_%s%s", title, timestamp, format.getExtension());
+    }
+
+    private String formatDateTime(LocalDateTime dateTime) {
+        if (dateTime == null) return "";
+        return dateTime.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
+    }
+}
+

--- a/src/main/resources/templates/export/business-plan-template.html
+++ b/src/main/resources/templates/export/business-plan-template.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8"/>
+    <title th:text="${projectTitle}">사업계획서</title>
+    <style>
+        @page {
+            size: A4;
+            margin: 2.5cm;
+        }
+        
+        * {
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: 'Malgun Gothic', '맑은 고딕', sans-serif;
+            font-size: 11pt;
+            line-height: 1.8;
+            color: #333;
+            margin: 0;
+            padding: 0;
+        }
+        
+        /* 표지 */
+        .cover-page {
+            text-align: center;
+            padding-top: 200px;
+            page-break-after: always;
+        }
+        
+        .cover-page h1 {
+            font-size: 28pt;
+            font-weight: bold;
+            margin-bottom: 30px;
+            color: #1a365d;
+        }
+        
+        .cover-page .template-name {
+            font-size: 14pt;
+            color: #4a5568;
+            margin-bottom: 100px;
+        }
+        
+        .cover-page .meta-info {
+            font-size: 12pt;
+            color: #718096;
+        }
+        
+        /* 목차 */
+        .toc-page {
+            page-break-after: always;
+        }
+        
+        .toc-page h2 {
+            font-size: 18pt;
+            color: #1a365d;
+            border-bottom: 2px solid #1a365d;
+            padding-bottom: 10px;
+            margin-bottom: 30px;
+        }
+        
+        .toc-list {
+            list-style: none;
+            padding: 0;
+        }
+        
+        .toc-list li {
+            padding: 10px 0;
+            border-bottom: 1px dotted #ccc;
+            font-size: 12pt;
+        }
+        
+        /* 섹션 스타일 */
+        .section {
+            page-break-inside: avoid;
+            margin-bottom: 40px;
+        }
+        
+        .section-title {
+            font-size: 16pt;
+            font-weight: bold;
+            color: #1a365d;
+            border-bottom: 2px solid #3182ce;
+            padding-bottom: 8px;
+            margin-bottom: 20px;
+            margin-top: 30px;
+        }
+        
+        .section-content {
+            text-align: justify;
+            white-space: pre-wrap;
+        }
+        
+        .section-content p {
+            margin-bottom: 15px;
+        }
+        
+        /* 페이지 구분 */
+        .page-break {
+            page-break-before: always;
+        }
+        
+        /* 푸터 */
+        .footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            text-align: center;
+            font-size: 9pt;
+            color: #718096;
+            padding: 10px;
+        }
+    </style>
+</head>
+<body>
+
+<!-- 표지 -->
+<div class="cover-page">
+    <h1 th:text="${projectTitle}">사업계획서</h1>
+    <p class="template-name" th:text="${templateName}">예비창업패키지 2025</p>
+    <div class="meta-info">
+        <p>버전: <span th:text="${version}">1</span></p>
+        <p>작성일: <span th:text="${createdAt}">2025년 01월 01일</span></p>
+        <p>총 글자 수: <span th:text="${#numbers.formatInteger(totalWordCount, 0, 'COMMA')}">0</span>자</p>
+    </div>
+</div>
+
+<!-- 목차 -->
+<div class="toc-page">
+    <h2>목차</h2>
+    <ol class="toc-list">
+        <li th:if="${sections.executiveSummary}">1. 요약 (Executive Summary)</li>
+        <li th:if="${sections.problemDefinition}">2. 문제 정의</li>
+        <li th:if="${sections.solution}">3. 솔루션</li>
+        <li th:if="${sections.marketAnalysis}">4. 시장 분석</li>
+        <li th:if="${sections.businessModel}">5. 비즈니스 모델</li>
+        <li th:if="${sections.competitiveAnalysis}">6. 경쟁 분석</li>
+        <li th:if="${sections.marketingStrategy}">7. 마케팅 전략</li>
+        <li th:if="${sections.team}">8. 팀 소개</li>
+        <li th:if="${sections.financialPlan}">9. 재무 계획</li>
+        <li th:if="${sections.milestones}">10. 마일스톤</li>
+    </ol>
+</div>
+
+<!-- 본문 -->
+<div class="content">
+
+    <!-- 1. 요약 -->
+    <div class="section" th:if="${sections.executiveSummary}">
+        <h2 class="section-title">1. 요약 (Executive Summary)</h2>
+        <div class="section-content" th:text="${sections.executiveSummary}"></div>
+    </div>
+
+    <!-- 2. 문제 정의 -->
+    <div class="section page-break" th:if="${sections.problemDefinition}">
+        <h2 class="section-title">2. 문제 정의</h2>
+        <div class="section-content" th:text="${sections.problemDefinition}"></div>
+    </div>
+
+    <!-- 3. 솔루션 -->
+    <div class="section page-break" th:if="${sections.solution}">
+        <h2 class="section-title">3. 솔루션</h2>
+        <div class="section-content" th:text="${sections.solution}"></div>
+    </div>
+
+    <!-- 4. 시장 분석 -->
+    <div class="section page-break" th:if="${sections.marketAnalysis}">
+        <h2 class="section-title">4. 시장 분석</h2>
+        <div class="section-content" th:text="${sections.marketAnalysis}"></div>
+    </div>
+
+    <!-- 5. 비즈니스 모델 -->
+    <div class="section page-break" th:if="${sections.businessModel}">
+        <h2 class="section-title">5. 비즈니스 모델</h2>
+        <div class="section-content" th:text="${sections.businessModel}"></div>
+    </div>
+
+    <!-- 6. 경쟁 분석 -->
+    <div class="section page-break" th:if="${sections.competitiveAnalysis}">
+        <h2 class="section-title">6. 경쟁 분석</h2>
+        <div class="section-content" th:text="${sections.competitiveAnalysis}"></div>
+    </div>
+
+    <!-- 7. 마케팅 전략 -->
+    <div class="section page-break" th:if="${sections.marketingStrategy}">
+        <h2 class="section-title">7. 마케팅 전략</h2>
+        <div class="section-content" th:text="${sections.marketingStrategy}"></div>
+    </div>
+
+    <!-- 8. 팀 소개 -->
+    <div class="section page-break" th:if="${sections.team}">
+        <h2 class="section-title">8. 팀 소개</h2>
+        <div class="section-content" th:text="${sections.team}"></div>
+    </div>
+
+    <!-- 9. 재무 계획 -->
+    <div class="section page-break" th:if="${sections.financialPlan}">
+        <h2 class="section-title">9. 재무 계획</h2>
+        <div class="section-content" th:text="${sections.financialPlan}"></div>
+    </div>
+
+    <!-- 10. 마일스톤 -->
+    <div class="section page-break" th:if="${sections.milestones}">
+        <h2 class="section-title">10. 마일스톤</h2>
+        <div class="section-content" th:text="${sections.milestones}"></div>
+    </div>
+
+</div>
+
+</body>
+</html>
+


### PR DESCRIPTION
## 개요
- 이슈: #11
- 생성된 사업계획서를 PDF/HTML 형식으로 다운로드하는 기능

## 구현 내용

### 서비스
- `DocumentExportService`: PDF/HTML 변환 로직
- Thymeleaf 템플릿을 사용한 HTML 렌더링
- Flying Saucer를 사용한 HTML→PDF 변환

### REST API
| Method | Endpoint | 설명 |
|--------|----------|------|
| GET | `/projects/{id}/export?format=pdf` | PDF 다운로드 |
| GET | `/projects/{id}/export?format=html` | HTML 다운로드 |
| GET | `/projects/{id}/export/versions/{v}` | 특정 버전 내보내기 |
| GET | `/projects/{id}/export/formats` | 지원 형식 목록 |

### 템플릿
- A4 포맷 PDF 템플릿
- 표지, 목차, 섹션별 레이아웃
- 한글 폰트 지원 (맑은 고딕)

## 참고사항
- HWP 형식은 라이선스 및 라이브러리 가용성 문제로 MVP에서 제외
- 향후 Apache POI 또는 별도 변환 서비스를 통해 HWP 지원 예정

## 체크리스트
- [x] 빌드 성공
- [x] PDF 내보내기 구현
- [x] HTML 내보내기 구현
- [x] 템플릿 디자인
- [x] API 엔드포인트 구현