### PR TITLE
fix: TemplateCode enum IDE Lombok 인식 오류 수정

### DIFF
--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/model/TemplateCode.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/model/TemplateCode.java
@@ -1,14 +1,9 @@
 package com.vibe.bizplan.bizplan_be.domain.model;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 /**
  * 사업계획서 템플릿 코드 열거형.
  * 지원하는 정부지원사업 및 대출용 템플릿 목록을 하드코딩으로 관리한다.
  */
-@Getter
-@RequiredArgsConstructor
 public enum TemplateCode {
     
     /** 예비창업패키지 2025 */
@@ -34,5 +29,56 @@ public enum TemplateCode {
     
     /** Wizard 전체 단계 수 */
     private final int totalSteps;
+
+    /**
+     * 생성자.
+     *
+     * @param displayName 템플릿 표시명
+     * @param description 템플릿 설명
+     * @param category 템플릿 카테고리
+     * @param totalSteps Wizard 전체 단계 수
+     */
+    TemplateCode(String displayName, String description, String category, int totalSteps) {
+        this.displayName = displayName;
+        this.description = description;
+        this.category = category;
+        this.totalSteps = totalSteps;
+    }
+
+    /**
+     * 템플릿 표시명 반환.
+     *
+     * @return 템플릿 표시명
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * 템플릿 설명 반환.
+     *
+     * @return 템플릿 설명
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * 템플릿 카테고리 반환.
+     *
+     * @return 템플릿 카테고리 (government, bank, investor)
+     */
+    public String getCategory() {
+        return category;
+    }
+
+    /**
+     * Wizard 전체 단계 수 반환.
+     *
+     * @return Wizard 전체 단계 수
+     */
+    public int getTotalSteps() {
+        return totalSteps;
+    }
 }
 


### PR DESCRIPTION
## 📋 변경 사항 요약

### 문제
- `ProjectService.java` 58번 줄에서 `getTotalSteps()` 메서드를 찾지 못하는 IDE 컴파일 오류 발생
- Lombok `@Getter` 어노테이션이 IDE에서 제대로 인식되지 않음

### 해결
- `TemplateCode` enum에서 Lombok 어노테이션 제거
- 명시적 생성자 및 getter 메서드 추가

## 🔧 변경 파일

### `src/main/java/com/vibe/bizplan/bizplan_be/domain/model/TemplateCode.java`
- `@Getter`, `@RequiredArgsConstructor` 어노테이션 제거
- 명시적 생성자 추가
- `getDisplayName()`, `getDescription()`, `getCategory()`, `getTotalSteps()` getter 메서드 명시적 구현

## ✅ 테스트

- [x] `./gradlew clean compileJava` - 빌드 성공
- [x] `./gradlew test` - 전체 테스트 통과

## 📝 비고
- 기존 동작에 영향 없음 (Lombok이 생성하던 메서드를 명시적으로 작성)