### PR TITLE
refactor: Project Entity 불변성 강화 (@Setter 제거)

### DIFF
--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/entity/Project.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/entity/Project.java
@@ -4,7 +4,11 @@ import com.vibe.bizplan.bizplan_be.domain.model.ProjectStatus;
 import com.vibe.bizplan.bizplan_be.domain.model.TemplateCode;
 import com.vibe.bizplan.bizplan_be.infrastructure.security.EncryptedStringConverter;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -14,11 +18,12 @@ import java.util.UUID;
 /**
  * 사업계획서 프로젝트 엔티티.
  * 사용자가 생성한 사업계획서 프로젝트의 메타데이터를 관리한다.
+ * 
+ * <p>불변성 강화: @Setter 대신 도메인 메서드(updateTitle, changeStatus, updateWizardAnswers)를 통해서만 상태 변경 가능</p>
  */
 @Entity
 @Table(name = "projects")
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder


### PR DESCRIPTION
## 📋 변경 사항 요약

### 목적
- Entity 불변성 강화를 위해 `@Setter` 어노테이션 제거
- Domain-Driven Design 패턴 적용

### 변경 내용

#### Before
```java
@Getter
@Setter  // ❌ 모든 필드에 setter 생성
public class Project { ... }
```

#### After
```java
@Getter  // ✅ @Setter 제거
public class Project {
    // 도메인 메서드로만 상태 변경 가능
    public void updateTitle(String title) { ... }
    public void changeStatus(ProjectStatus status) { ... }
    public void updateWizardAnswers(String wizardAnswers) { ... }
}
```

## 🔧 변경 파일

### `src/main/java/.../domain/entity/Project.java`
- `@Setter` 어노테이션 제거
- `import lombok.*` → 명시적 import로 변경
- Javadoc에 불변성 패턴 설명 추가

## ✅ 불변성 강화 효과

| 작업 | Before | After |
|------|--------|-------|
| `project.setId(...)` | ✅ 가능 | ❌ 불가 |
| `project.setTemplateCode(...)` | ✅ 가능 | ❌ 불가 |
| `project.updateTitle(...)` | ✅ 가능 | ✅ 가능 |
| `project.changeStatus(...)` | ✅ 가능 | ✅ 가능 |

## ✅ 테스트 결과

- [x] `./gradlew clean test` - 전체 테스트 통과
- [x] 기존 코드에서 setter 사용처 없음 확인