### PR TITLE
[BE-API-001] 프로젝트 수정 API 구현

### DIFF
--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/ProjectController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/ProjectController.java
@@ -4,6 +4,7 @@ import com.vibe.bizplan.bizplan_be.domain.entity.User;
 import com.vibe.bizplan.bizplan_be.domain.service.ProjectService;
 import com.vibe.bizplan.bizplan_be.domain.service.TemplateService;
 import com.vibe.bizplan.bizplan_be.dto.request.CreateProjectRequest;
+import com.vibe.bizplan.bizplan_be.dto.request.UpdateProjectRequest;
 import com.vibe.bizplan.bizplan_be.dto.response.ProjectResponse;
 import com.vibe.bizplan.bizplan_be.dto.response.TemplateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -165,5 +166,44 @@ public class ProjectController {
             log.debug("[Project] 프로젝트 목록 조회 완료 (MVP) - count={}", projects.size());
         }
         return ResponseEntity.ok(projects);
+    }
+
+    /**
+     * 프로젝트 수정.
+     * 제공된 필드만 업데이트하며, null 값은 무시된다.
+     * 인증된 사용자의 경우 소유권 검증 수행.
+     * MVP: 인증 없이도 수정 가능.
+     *
+     * @param projectId 프로젝트 ID
+     * @param request 수정 요청 DTO
+     * @param user 현재 인증된 사용자 (없을 수 있음)
+     * @return 수정된 프로젝트 정보
+     */
+    @PatchMapping("/{projectId}")
+    @Operation(summary = "프로젝트 수정", description = "프로젝트 제목 및 상태를 수정합니다. 제공된 필드만 업데이트됩니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = ProjectResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public ResponseEntity<ProjectResponse> updateProject(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Valid @RequestBody UpdateProjectRequest request,
+            @AuthenticationPrincipal User user
+    ) {
+        ProjectResponse response;
+        if (user != null) {
+            // 인증된 사용자: 소유권 검증
+            response = projectService.updateProject(projectId, request, user.getId(), user.getRole());
+            log.debug("[Project] 프로젝트 수정 완료 - projectId={}, userId={}", projectId, user.getId());
+        } else {
+            // MVP: 검증 없이 수정
+            response = projectService.updateProject(projectId, request);
+            log.debug("[Project] 프로젝트 수정 완료 (MVP) - projectId={}", projectId);
+        }
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/ProjectService.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/ProjectService.java
@@ -15,6 +15,7 @@ import com.vibe.bizplan.bizplan_be.domain.model.BizPlanConstants;
 import com.vibe.bizplan.bizplan_be.domain.model.TemplateCode;
 import com.vibe.bizplan.bizplan_be.domain.model.UserRole;
 import com.vibe.bizplan.bizplan_be.dto.request.CreateProjectRequest;
+import com.vibe.bizplan.bizplan_be.dto.request.UpdateProjectRequest;
 import com.vibe.bizplan.bizplan_be.dto.response.ProjectResponse;
 import com.vibe.bizplan.bizplan_be.dto.response.ProjectResponseMapper;
 import com.vibe.bizplan.bizplan_be.infrastructure.repository.ProjectRepository;
@@ -228,5 +229,58 @@ public class ProjectService {
         }
         
         return project;
+    }
+
+    /**
+     * 프로젝트 수정.
+     * 제공된 필드만 업데이트하며, null 값은 무시된다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param request 수정 요청 DTO
+     * @param userId 요청자 사용자 ID
+     * @param userRole 요청자 역할
+     * @return 수정된 프로젝트 응답 DTO
+     * @throws ProjectNotFoundException 프로젝트를 찾을 수 없는 경우
+     * @throws ResourceAccessDeniedException 접근 권한이 없는 경우
+     */
+    @Transactional
+    public ProjectResponse updateProject(String projectId, UpdateProjectRequest request, 
+                                         String userId, UserRole userRole) {
+        Objects.requireNonNull(projectId, "프로젝트 ID는 필수입니다");
+        Objects.requireNonNull(request, "요청 데이터는 필수입니다");
+        
+        log.info("[Project] 프로젝트 수정 시작 - projectId={}, userId={}", projectId, userId);
+        
+        // 프로젝트 조회 및 소유권 검증
+        Project project = getProjectEntity(projectId, userId, userRole);
+        
+        // 제공된 필드만 업데이트
+        if (request.title() != null) {
+            project.updateTitle(request.title());
+            log.debug("[Project] 제목 업데이트 - projectId={}, newTitle={}", projectId, request.title());
+        }
+        
+        if (request.status() != null) {
+            project.changeStatus(request.status());
+            log.debug("[Project] 상태 업데이트 - projectId={}, newStatus={}", projectId, request.status());
+        }
+        
+        Project savedProject = projectRepository.save(project);
+        ProjectResponse response = projectResponseMapper.toResponse(savedProject);
+        
+        log.info("[Project] 프로젝트 수정 완료 - projectId={}", projectId);
+        return response;
+    }
+
+    /**
+     * 프로젝트 수정 (MVP 호환용 - 기본 사용자).
+     *
+     * @param projectId 프로젝트 ID
+     * @param request 수정 요청 DTO
+     * @return 수정된 프로젝트 응답 DTO
+     */
+    @Transactional
+    public ProjectResponse updateProject(String projectId, UpdateProjectRequest request) {
+        return updateProject(projectId, request, BizPlanConstants.DEFAULT_USER_ID, UserRole.USER);
     }
 }

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/UpdateProjectRequest.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/UpdateProjectRequest.java
@@ -1,0 +1,21 @@
+package com.vibe.bizplan.bizplan_be.dto.request;
+
+import com.vibe.bizplan.bizplan_be.domain.model.ProjectStatus;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 프로젝트 수정 요청 DTO.
+ * 클라이언트에서 전송하는 프로젝트 수정 요청 데이터.
+ * 모든 필드는 선택적(Optional)이며, 제공된 필드만 업데이트된다.
+ */
+public record UpdateProjectRequest(
+        
+        /** 프로젝트 제목 (선택, 최대 255자) */
+        @Size(max = 255, message = "프로젝트 제목은 255자 이내여야 합니다")
+        String title,
+        
+        /** 프로젝트 상태 (선택) */
+        ProjectStatus status
+) {
+}
+


### PR DESCRIPTION
## 📋 요약
프로젝트 제목 및 상태를 수정할 수 있는 PATCH API 엔드포인트 구현

## 🎯 변경사항
- `PATCH /projects/{projectId}` 엔드포인트 추가
- `UpdateProjectRequest` DTO 생성 (title, status 필드)
- `ProjectService.updateProject()` 메서드 구현
- 소유권 검증 및 MVP 호환 지원
- Swagger 문서화 완료

## 📝 API 스펙
```
PATCH /projects/{projectId}
Authorization: Bearer {token}

Request Body:
{
  "title": "수정된 프로젝트명",
  "status": "IN_PROGRESS"
}

Response (200 OK):
{
  "projectId": "...",
  "templateCode": "...",
  "title": "수정된 프로젝트명",
  "status": "IN_PROGRESS",
  ...
}
```

## ✅ 체크리스트
- [x] 코드 빌드 성공
- [x] Swagger 문서화
- [x] 소유권 검증 로직

Closes #48