### PR TITLE
[BE-API-002] 프로젝트 삭제 API 구현

### DIFF
--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/ProjectController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/ProjectController.java
@@ -206,4 +206,37 @@ public class ProjectController {
         }
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 프로젝트 삭제.
+     * 인증된 사용자의 경우 소유권 검증 수행.
+     * MVP: 인증 없이도 삭제 가능.
+     *
+     * @param projectId 프로젝트 ID
+     * @param user 현재 인증된 사용자 (없을 수 있음)
+     * @return 204 No Content
+     */
+    @DeleteMapping("/{projectId}")
+    @Operation(summary = "프로젝트 삭제", description = "프로젝트를 삭제합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public ResponseEntity<Void> deleteProject(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @AuthenticationPrincipal User user
+    ) {
+        if (user != null) {
+            // 인증된 사용자: 소유권 검증
+            projectService.deleteProject(projectId, user.getId(), user.getRole());
+            log.debug("[Project] 프로젝트 삭제 완료 - projectId={}, userId={}", projectId, user.getId());
+        } else {
+            // MVP: 검증 없이 삭제
+            projectService.deleteProject(projectId);
+            log.debug("[Project] 프로젝트 삭제 완료 (MVP) - projectId={}", projectId);
+        }
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/ProjectService.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/ProjectService.java
@@ -283,4 +283,39 @@ public class ProjectService {
     public ProjectResponse updateProject(String projectId, UpdateProjectRequest request) {
         return updateProject(projectId, request, BizPlanConstants.DEFAULT_USER_ID, UserRole.USER);
     }
+
+    /**
+     * 프로젝트 삭제.
+     * 프로젝트와 관련된 모든 데이터를 삭제한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param userId 요청자 사용자 ID
+     * @param userRole 요청자 역할
+     * @throws ProjectNotFoundException 프로젝트를 찾을 수 없는 경우
+     * @throws ResourceAccessDeniedException 접근 권한이 없는 경우
+     */
+    @Transactional
+    public void deleteProject(String projectId, String userId, UserRole userRole) {
+        Objects.requireNonNull(projectId, "프로젝트 ID는 필수입니다");
+        
+        log.info("[Project] 프로젝트 삭제 시작 - projectId={}, userId={}", projectId, userId);
+        
+        // 프로젝트 조회 및 소유권 검증
+        Project project = getProjectEntity(projectId, userId, userRole);
+        
+        // 프로젝트 삭제
+        projectRepository.delete(project);
+        
+        log.info("[Project] 프로젝트 삭제 완료 - projectId={}", projectId);
+    }
+
+    /**
+     * 프로젝트 삭제 (MVP 호환용 - 기본 사용자).
+     *
+     * @param projectId 프로젝트 ID
+     */
+    @Transactional
+    public void deleteProject(String projectId) {
+        deleteProject(projectId, BizPlanConstants.DEFAULT_USER_ID, UserRole.USER);
+    }
 }


### PR DESCRIPTION
## 📋 요약
프로젝트를 삭제할 수 있는 DELETE API 엔드포인트 구현

## 🎯 변경사항
- `DELETE /projects/{projectId}` 엔드포인트 추가
- `ProjectService.deleteProject()` 메서드 구현
- 소유권 검증 및 MVP 호환 지원
- 204 No Content 응답 반환
- Swagger 문서화 완료

## 📝 API 스펙
```
DELETE /projects/{projectId}
Authorization: Bearer {token}

Response: 204 No Content
```

## ✅ 체크리스트
- [x] 코드 빌드 성공
- [x] Swagger 문서화
- [x] 소유권 검증 로직

Closes #49