### PR TITLE
[BE-API-003] 위저드 단계 정의 조회 API 구현

### DIFF
--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/WizardController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/WizardController.java
@@ -1,8 +1,11 @@
 package com.vibe.bizplan.bizplan_be.api;
 
+import com.vibe.bizplan.bizplan_be.domain.service.ProjectService;
 import com.vibe.bizplan.bizplan_be.domain.service.WizardService;
+import com.vibe.bizplan.bizplan_be.domain.service.WizardStepsService;
 import com.vibe.bizplan.bizplan_be.dto.request.SaveWizardAnswersRequest;
 import com.vibe.bizplan.bizplan_be.dto.response.WizardAnswersResponse;
+import com.vibe.bizplan.bizplan_be.dto.response.WizardStepsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -30,6 +33,32 @@ import java.util.Map;
 public class WizardController {
 
     private final WizardService wizardService;
+    private final WizardStepsService wizardStepsService;
+    private final ProjectService projectService;
+
+    /**
+     * 위저드 단계 정의 조회.
+     * 프로젝트 템플릿에 해당하는 위저드 단계 및 질문 정의를 반환한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 위저드 단계 정의
+     */
+    @GetMapping("/steps")
+    @Operation(summary = "위저드 단계 정의 조회", description = "프로젝트 템플릿에 해당하는 위저드 단계 및 질문 정의를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = WizardStepsResponse.class))),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public ResponseEntity<WizardStepsResponse> getWizardSteps(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId
+    ) {
+        var project = projectService.getProjectEntity(projectId);
+        WizardStepsResponse response = wizardStepsService.getWizardSteps(project.getTemplateCode());
+        log.debug("[Wizard] 위저드 단계 정의 조회 완료 - projectId={}, templateCode={}, totalSteps={}", 
+                projectId, project.getTemplateCode(), response.totalSteps());
+        return ResponseEntity.ok(response);
+    }
 
     /**
      * Wizard 답변 저장 (Upsert).

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/WizardStepsService.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/WizardStepsService.java
@@ -1,0 +1,219 @@
+package com.vibe.bizplan.bizplan_be.domain.service;
+
+import com.vibe.bizplan.bizplan_be.domain.model.TemplateCode;
+import com.vibe.bizplan.bizplan_be.dto.response.WizardQuestionResponse;
+import com.vibe.bizplan.bizplan_be.dto.response.WizardQuestionResponse.QuestionOption;
+import com.vibe.bizplan.bizplan_be.dto.response.WizardStepDefinitionResponse;
+import com.vibe.bizplan.bizplan_be.dto.response.WizardStepsResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 위저드 단계 정의 서비스.
+ * 템플릿별 위저드 단계 및 질문 정의를 제공한다.
+ * MVP에서는 하드코딩된 정의를 반환한다.
+ */
+@Slf4j
+@Service
+public class WizardStepsService {
+
+    /**
+     * 템플릿별 위저드 단계 정의 조회.
+     *
+     * @param templateCode 템플릿 코드
+     * @return 위저드 단계 정의 응답
+     */
+    public WizardStepsResponse getWizardSteps(TemplateCode templateCode) {
+        log.info("[WizardSteps] 위저드 단계 정의 조회 - templateCode={}", templateCode);
+        
+        // MVP: 모든 템플릿에 동일한 기본 단계 정의 사용
+        List<WizardStepDefinitionResponse> steps = getDefaultSteps();
+        
+        return new WizardStepsResponse(
+                templateCode.name().toLowerCase(),
+                steps.size(),
+                steps
+        );
+    }
+
+    /**
+     * 기본 위저드 단계 정의.
+     * MVP용 하드코딩된 단계 정의를 반환한다.
+     */
+    private List<WizardStepDefinitionResponse> getDefaultSteps() {
+        return List.of(
+                // Step 1: 사업 아이디어
+                new WizardStepDefinitionResponse(
+                        1,
+                        "사업 아이디어",
+                        "사업 아이디어를 설명해주세요",
+                        List.of(
+                                new WizardQuestionResponse(
+                                        "business-name",
+                                        "text",
+                                        "사업명",
+                                        "사업명을 입력하세요",
+                                        true,
+                                        100,
+                                        null
+                                ),
+                                new WizardQuestionResponse(
+                                        "business-description",
+                                        "textarea",
+                                        "사업 설명",
+                                        "사업 아이디어를 설명해주세요",
+                                        true,
+                                        1000,
+                                        null
+                                ),
+                                new WizardQuestionResponse(
+                                        "problem-statement",
+                                        "textarea",
+                                        "해결하고자 하는 문제",
+                                        "고객이 겪고 있는 문제를 설명해주세요",
+                                        true,
+                                        1000,
+                                        null
+                                )
+                        )
+                ),
+                // Step 2: 목표 시장
+                new WizardStepDefinitionResponse(
+                        2,
+                        "목표 시장",
+                        "목표 시장을 정의해주세요",
+                        List.of(
+                                new WizardQuestionResponse(
+                                        "target-customer",
+                                        "textarea",
+                                        "목표 고객",
+                                        "주요 목표 고객층을 설명해주세요",
+                                        true,
+                                        500,
+                                        null
+                                ),
+                                new WizardQuestionResponse(
+                                        "market-size",
+                                        "select",
+                                        "시장 규모",
+                                        "예상 시장 규모를 선택하세요",
+                                        true,
+                                        null,
+                                        List.of(
+                                                new QuestionOption("small", "소규모 (10억 미만)"),
+                                                new QuestionOption("medium", "중규모 (10억 ~ 100억)"),
+                                                new QuestionOption("large", "대규모 (100억 ~ 1000억)"),
+                                                new QuestionOption("enterprise", "엔터프라이즈 (1000억 이상)")
+                                        )
+                                ),
+                                new WizardQuestionResponse(
+                                        "competitors",
+                                        "textarea",
+                                        "경쟁사",
+                                        "주요 경쟁사와 차별점을 설명해주세요",
+                                        false,
+                                        500,
+                                        null
+                                )
+                        )
+                ),
+                // Step 3: 비즈니스 모델
+                new WizardStepDefinitionResponse(
+                        3,
+                        "비즈니스 모델",
+                        "수익 창출 방법을 설명해주세요",
+                        List.of(
+                                new WizardQuestionResponse(
+                                        "revenue-model",
+                                        "multiselect",
+                                        "수익 모델",
+                                        "수익 창출 방법을 선택하세요 (복수 선택 가능)",
+                                        true,
+                                        null,
+                                        List.of(
+                                                new QuestionOption("subscription", "구독형"),
+                                                new QuestionOption("one-time", "일회성 판매"),
+                                                new QuestionOption("commission", "수수료"),
+                                                new QuestionOption("advertising", "광고"),
+                                                new QuestionOption("freemium", "프리미엄"),
+                                                new QuestionOption("other", "기타")
+                                        )
+                                ),
+                                new WizardQuestionResponse(
+                                        "pricing",
+                                        "textarea",
+                                        "가격 정책",
+                                        "예상 가격대와 가격 책정 근거를 설명해주세요",
+                                        true,
+                                        500,
+                                        null
+                                )
+                        )
+                ),
+                // Step 4: 실행 계획
+                new WizardStepDefinitionResponse(
+                        4,
+                        "실행 계획",
+                        "사업 실행 계획을 수립해주세요",
+                        List.of(
+                                new WizardQuestionResponse(
+                                        "milestones",
+                                        "textarea",
+                                        "주요 마일스톤",
+                                        "향후 12개월 주요 달성 목표를 설명해주세요",
+                                        true,
+                                        1000,
+                                        null
+                                ),
+                                new WizardQuestionResponse(
+                                        "team",
+                                        "textarea",
+                                        "팀 구성",
+                                        "현재 팀 구성과 필요한 인력을 설명해주세요",
+                                        false,
+                                        500,
+                                        null
+                                ),
+                                new WizardQuestionResponse(
+                                        "funding-needed",
+                                        "number",
+                                        "필요 자금 (원)",
+                                        "초기 필요 자금을 입력하세요",
+                                        true,
+                                        null,
+                                        null
+                                )
+                        )
+                ),
+                // Step 5: 리스크 분석
+                new WizardStepDefinitionResponse(
+                        5,
+                        "리스크 분석",
+                        "예상되는 리스크와 대응 방안을 검토합니다",
+                        List.of(
+                                new WizardQuestionResponse(
+                                        "risks",
+                                        "textarea",
+                                        "주요 리스크",
+                                        "예상되는 주요 리스크를 설명해주세요",
+                                        true,
+                                        1000,
+                                        null
+                                ),
+                                new WizardQuestionResponse(
+                                        "mitigation",
+                                        "textarea",
+                                        "리스크 대응 방안",
+                                        "각 리스크에 대한 대응 방안을 설명해주세요",
+                                        true,
+                                        1000,
+                                        null
+                                )
+                        )
+                )
+        );
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/WizardQuestionResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/WizardQuestionResponse.java
@@ -1,0 +1,41 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import java.util.List;
+
+/**
+ * 위저드 질문 정의 응답 DTO.
+ * 위저드 단계 내 개별 질문의 정의 정보를 담는다.
+ */
+public record WizardQuestionResponse(
+        /** 질문 ID */
+        String id,
+        
+        /** 질문 유형 (text, textarea, number, select, multiselect, date, radio) */
+        String type,
+        
+        /** 질문 라벨 */
+        String label,
+        
+        /** 입력 플레이스홀더 */
+        String placeholder,
+        
+        /** 필수 여부 */
+        boolean required,
+        
+        /** 최대 길이 (text, textarea) */
+        Integer maxLength,
+        
+        /** 선택 옵션 목록 (select, multiselect, radio) */
+        List<QuestionOption> options
+) {
+    /**
+     * 선택 옵션 정의.
+     */
+    public record QuestionOption(
+            /** 옵션 값 */
+            Object value,
+            /** 옵션 라벨 */
+            String label
+    ) {}
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/WizardStepDefinitionResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/WizardStepDefinitionResponse.java
@@ -1,0 +1,23 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import java.util.List;
+
+/**
+ * 위저드 단계 정의 응답 DTO.
+ * 위저드의 개별 단계 정의 정보를 담는다.
+ */
+public record WizardStepDefinitionResponse(
+        /** 단계 ID */
+        int id,
+        
+        /** 단계 제목 */
+        String title,
+        
+        /** 단계 설명 */
+        String description,
+        
+        /** 해당 단계의 질문 목록 */
+        List<WizardQuestionResponse> questions
+) {
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/WizardStepsResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/WizardStepsResponse.java
@@ -1,0 +1,20 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import java.util.List;
+
+/**
+ * 위저드 단계 전체 정의 응답 DTO.
+ * 템플릿별 위저드 단계 및 질문 정의 목록을 담는다.
+ */
+public record WizardStepsResponse(
+        /** 템플릿 코드 */
+        String templateCode,
+        
+        /** 총 단계 수 */
+        int totalSteps,
+        
+        /** 단계 정의 목록 */
+        List<WizardStepDefinitionResponse> steps
+) {
+}
+


### PR DESCRIPTION
## 📋 요약
템플릿별 위저드 단계 및 질문 정의를 조회하는 API 구현

## 🎯 변경사항
- `GET /projects/{projectId}/wizard/steps` 엔드포인트 추가
- `WizardStepsResponse`, `WizardStepDefinitionResponse`, `WizardQuestionResponse` DTO 생성
- `WizardStepsService` 구현 (MVP: 하드코딩된 5단계 정의)
- 단계별 질문 유형 지원: text, textarea, number, select, multiselect
- Swagger 문서화 완료

## 📝 위저드 단계 정의 (MVP)
1. 사업 아이디어 - 사업명, 설명, 문제정의
2. 목표 시장 - 고객, 시장규모, 경쟁사
3. 비즈니스 모델 - 수익모델, 가격정책
4. 실행 계획 - 마일스톤, 팀구성, 필요자금
5. 리스크 분석 - 리스크, 대응방안

Closes #50