### PR TITLE
[BE-API-004] 재무 데이터 조회 API 구현

### DIFF
--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/FinancialController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/FinancialController.java
@@ -1,6 +1,7 @@
 package com.vibe.bizplan.bizplan_be.api;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,6 +67,39 @@ public class FinancialController {
                 request.projectionMonths(), response.unitEconomics().breakEvenMonth());
         
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 저장된 재무 데이터 조회.
+     * 이전에 생성된 재무 추정 결과를 조회한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 재무 추정 결과 (없으면 404)
+     */
+    @GetMapping
+    @Operation(
+            summary = "재무 데이터 조회",
+            description = "저장된 재무 추정 결과를 조회합니다. 재무 데이터가 없는 경우 404를 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = FinancialProjectionResponse.class))),
+            @ApiResponse(responseCode = "404", description = "재무 데이터 없음")
+    })
+    public ResponseEntity<FinancialProjectionResponse> getFinancials(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId
+    ) {
+        log.info("GET /projects/{}/financials", projectId);
+        
+        return financialCalculationService.getFinancials(projectId)
+                .map(response -> {
+                    log.info("재무 데이터 조회 완료: projectId={}", projectId);
+                    return ResponseEntity.ok(response);
+                })
+                .orElseGet(() -> {
+                    log.info("재무 데이터 없음: projectId={}", projectId);
+                    return ResponseEntity.notFound().build();
+                });
     }
 
 }

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/entity/FinancialData.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/entity/FinancialData.java
@@ -1,0 +1,82 @@
+package com.vibe.bizplan.bizplan_be.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 재무 데이터 엔티티.
+ * 프로젝트별 재무 가정값과 계산 결과를 저장한다.
+ */
+@Entity
+@Table(name = "financial_data")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class FinancialData {
+
+    /** 고유 ID (UUID) */
+    @Id
+    @Column(name = "id", length = 36, nullable = false)
+    private String id;
+
+    /** 프로젝트 ID */
+    @Column(name = "project_id", length = 36, nullable = false, unique = true)
+    private String projectId;
+
+    /** 재무 가정값 (JSON) */
+    @Column(name = "assumptions", columnDefinition = "TEXT", nullable = false)
+    private String assumptions;
+
+    /** 계산된 재무 추정 결과 (JSON) */
+    @Column(name = "projection_result", columnDefinition = "TEXT")
+    private String projectionResult;
+
+    /** 생성일시 */
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 수정일시 */
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /**
+     * 새 재무 데이터 생성을 위한 정적 팩토리 메서드.
+     *
+     * @param projectId 프로젝트 ID
+     * @param assumptions 재무 가정값 JSON
+     * @param projectionResult 계산 결과 JSON
+     * @return 생성된 FinancialData 인스턴스
+     */
+    public static FinancialData create(String projectId, String assumptions, String projectionResult) {
+        return FinancialData.builder()
+                .id(UUID.randomUUID().toString())
+                .projectId(projectId)
+                .assumptions(assumptions)
+                .projectionResult(projectionResult)
+                .build();
+    }
+
+    /**
+     * 재무 데이터 업데이트.
+     *
+     * @param assumptions 새 가정값 JSON
+     * @param projectionResult 새 계산 결과 JSON
+     */
+    public void update(String assumptions, String projectionResult) {
+        this.assumptions = assumptions;
+        this.projectionResult = projectionResult;
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/FinancialCalculationService.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/FinancialCalculationService.java
@@ -1,16 +1,23 @@
 package com.vibe.bizplan.bizplan_be.domain.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vibe.bizplan.bizplan_be.domain.entity.FinancialData;
 import com.vibe.bizplan.bizplan_be.domain.model.BizPlanConstants;
 import com.vibe.bizplan.bizplan_be.dto.request.FinancialAssumptionsRequest;
 import com.vibe.bizplan.bizplan_be.dto.response.FinancialProjectionResponse;
 import com.vibe.bizplan.bizplan_be.dto.response.FinancialProjectionResponse.*;
+import com.vibe.bizplan.bizplan_be.infrastructure.repository.FinancialDataRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 재무 추정 계산 서비스.
@@ -18,18 +25,23 @@ import java.util.List;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class FinancialCalculationService {
+
+    private final FinancialDataRepository financialDataRepository;
+    private final ObjectMapper objectMapper;
 
     private static final int SCALE = 2;
     private static final RoundingMode ROUNDING = RoundingMode.HALF_UP;
 
     /**
-     * 재무 추정 생성.
+     * 재무 추정 생성 및 저장.
      *
      * @param projectId 프로젝트 ID
      * @param assumptions 재무 가정 변수
      * @return 재무 추정 결과
      */
+    @Transactional
     public FinancialProjectionResponse generateProjection(String projectId, FinancialAssumptionsRequest assumptions) {
         log.info("재무 추정 시작: projectId={}, months={}", projectId, assumptions.projectionMonths());
         
@@ -42,9 +54,62 @@ public class FinancialCalculationService {
         // 유닛 이코노믹스 계산
         UnitEconomics unitEconomics = calculateUnitEconomics(assumptions, monthlyPLList);
         
+        FinancialProjectionResponse response = new FinancialProjectionResponse(
+                projectId, monthlyPLList, yearlySummaryList, unitEconomics);
+        
+        // 재무 데이터 저장
+        saveFinancialData(projectId, assumptions, response);
+        
         log.info("재무 추정 완료: projectId={}", projectId);
         
-        return new FinancialProjectionResponse(projectId, monthlyPLList, yearlySummaryList, unitEconomics);
+        return response;
+    }
+
+    /**
+     * 저장된 재무 데이터 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 재무 추정 결과 (Optional)
+     */
+    @Transactional(readOnly = true)
+    public Optional<FinancialProjectionResponse> getFinancials(String projectId) {
+        log.info("재무 데이터 조회: projectId={}", projectId);
+        
+        return financialDataRepository.findByProjectId(projectId)
+                .map(data -> {
+                    try {
+                        return objectMapper.readValue(data.getProjectionResult(), FinancialProjectionResponse.class);
+                    } catch (JsonProcessingException e) {
+                        log.error("재무 데이터 파싱 실패: projectId={}", projectId, e);
+                        return null;
+                    }
+                });
+    }
+
+    /**
+     * 재무 데이터 저장 (내부 메서드).
+     */
+    private void saveFinancialData(String projectId, FinancialAssumptionsRequest assumptions, 
+                                   FinancialProjectionResponse response) {
+        try {
+            String assumptionsJson = objectMapper.writeValueAsString(assumptions);
+            String projectionJson = objectMapper.writeValueAsString(response);
+            
+            Optional<FinancialData> existing = financialDataRepository.findByProjectId(projectId);
+            
+            if (existing.isPresent()) {
+                existing.get().update(assumptionsJson, projectionJson);
+                financialDataRepository.save(existing.get());
+                log.debug("재무 데이터 업데이트: projectId={}", projectId);
+            } else {
+                FinancialData newData = FinancialData.create(projectId, assumptionsJson, projectionJson);
+                financialDataRepository.save(newData);
+                log.debug("재무 데이터 생성: projectId={}", projectId);
+            }
+        } catch (JsonProcessingException e) {
+            log.error("재무 데이터 직렬화 실패: projectId={}", projectId, e);
+            throw new RuntimeException("재무 데이터 저장 실패", e);
+        }
     }
 
     /**

--- a/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/repository/FinancialDataRepository.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/repository/FinancialDataRepository.java
@@ -1,0 +1,31 @@
+package com.vibe.bizplan.bizplan_be.infrastructure.repository;
+
+import com.vibe.bizplan.bizplan_be.domain.entity.FinancialData;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * 재무 데이터 리포지토리.
+ */
+@Repository
+public interface FinancialDataRepository extends JpaRepository<FinancialData, String> {
+    
+    /**
+     * 프로젝트 ID로 재무 데이터 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 재무 데이터 (Optional)
+     */
+    Optional<FinancialData> findByProjectId(String projectId);
+    
+    /**
+     * 프로젝트 ID로 재무 데이터 존재 여부 확인.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 존재 여부
+     */
+    boolean existsByProjectId(String projectId);
+}
+

--- a/src/main/resources/db/migration/V5__create_financial_data_table.sql
+++ b/src/main/resources/db/migration/V5__create_financial_data_table.sql
@@ -1,0 +1,17 @@
+-- V5: 재무 데이터 저장 테이블 생성
+-- 프로젝트별 재무 가정값과 계산 결과를 저장한다.
+
+CREATE TABLE financial_data (
+    id VARCHAR(36) PRIMARY KEY,
+    project_id VARCHAR(36) NOT NULL UNIQUE,
+    assumptions TEXT NOT NULL COMMENT 'JSON: 재무 가정값',
+    projection_result TEXT COMMENT 'JSON: 계산된 재무 추정 결과',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    
+    CONSTRAINT fk_financial_data_project 
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_financial_data_project_id ON financial_data(project_id);
+


### PR DESCRIPTION
## 📋 요약
저장된 재무 시뮬레이션 데이터를 조회하는 API 구현

## 🎯 변경사항
- `GET /projects/{projectId}/financials` 엔드포인트 추가
- `FinancialData` 엔티티 및 리포지토리 생성
- V5 마이그레이션: `financial_data` 테이블 생성
- `FinancialCalculationService`에 저장/조회 로직 추가
- 재무 생성 시 자동 저장, 조회 시 저장된 결과 반환
- Swagger 문서화 완료

## 📝 API 스펙
```
GET /projects/{projectId}/financials

Response (200 OK): 재무 추정 결과 (monthlyPL, yearlySummary, unitEconomics)
Response (404 Not Found): 재무 데이터 없음
```

Closes #51