### PR TITLE
[BE-API-005] 재무 가정값 저장 API 구현

### DIFF
--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/FinancialController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/FinancialController.java
@@ -4,9 +4,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.Map;
 
 import com.vibe.bizplan.bizplan_be.domain.service.FinancialCalculationService;
 import com.vibe.bizplan.bizplan_be.dto.request.FinancialAssumptionsRequest;
@@ -100,6 +104,39 @@ public class FinancialController {
                     log.info("재무 데이터 없음: projectId={}", projectId);
                     return ResponseEntity.notFound().build();
                 });
+    }
+
+    /**
+     * 재무 가정값 저장 (시뮬레이션 재실행 없이).
+     * 가정값만 저장하고 싶을 때 사용한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param request 재무 가정 변수
+     * @return 저장 결과
+     */
+    @PutMapping("/assumptions")
+    @Operation(
+            summary = "재무 가정값 저장",
+            description = "재무 가정값만 저장합니다. 시뮬레이션은 재실행하지 않습니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 변수")
+    })
+    public ResponseEntity<Map<String, Object>> saveAssumptions(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Valid @RequestBody FinancialAssumptionsRequest request
+    ) {
+        log.info("PUT /projects/{}/financials/assumptions", projectId);
+        
+        financialCalculationService.saveAssumptions(projectId, request);
+        
+        log.info("재무 가정값 저장 완료: projectId={}", projectId);
+        
+        return ResponseEntity.ok(Map.of(
+                "message", "저장되었습니다.",
+                "updatedAt", LocalDateTime.now().toString()
+        ));
     }
 
 }

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/FinancialCalculationService.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/FinancialCalculationService.java
@@ -87,6 +87,38 @@ public class FinancialCalculationService {
     }
 
     /**
+     * 재무 가정값만 저장 (시뮬레이션 재실행 없이).
+     *
+     * @param projectId 프로젝트 ID
+     * @param assumptions 재무 가정 변수
+     */
+    @Transactional
+    public void saveAssumptions(String projectId, FinancialAssumptionsRequest assumptions) {
+        log.info("재무 가정값 저장: projectId={}", projectId);
+        
+        try {
+            String assumptionsJson = objectMapper.writeValueAsString(assumptions);
+            
+            Optional<FinancialData> existing = financialDataRepository.findByProjectId(projectId);
+            
+            if (existing.isPresent()) {
+                // 기존 데이터가 있으면 가정값만 업데이트 (projection 결과는 유지)
+                existing.get().update(assumptionsJson, existing.get().getProjectionResult());
+                financialDataRepository.save(existing.get());
+                log.debug("재무 가정값 업데이트: projectId={}", projectId);
+            } else {
+                // 새로 생성 (projection 결과는 null)
+                FinancialData newData = FinancialData.create(projectId, assumptionsJson, null);
+                financialDataRepository.save(newData);
+                log.debug("재무 가정값 생성: projectId={}", projectId);
+            }
+        } catch (JsonProcessingException e) {
+            log.error("재무 가정값 직렬화 실패: projectId={}", projectId, e);
+            throw new RuntimeException("재무 가정값 저장 실패", e);
+        }
+    }
+
+    /**
      * 재무 데이터 저장 (내부 메서드).
      */
     private void saveFinancialData(String projectId, FinancialAssumptionsRequest assumptions, 


### PR DESCRIPTION
## 📋 요약
재무 가정값만 저장하는 API 구현 (시뮬레이션 재실행 없이)

## 🎯 변경사항
- `PUT /projects/{projectId}/financials/assumptions` 엔드포인트 추가
- `FinancialCalculationService.saveAssumptions()` 메서드 구현
- Auto-save 및 임시 저장 기능 지원
- Swagger 문서화 완료

## 📝 API 스펙
```
PUT /projects/{projectId}/financials/assumptions

Request Body: FinancialAssumptionsRequest (가정값)
Response (200 OK): { "message": "저장되었습니다.", "updatedAt": "..." }
```

Closes #52