### PR TITLE
[BE-API-006/007/008] PMF 진단 API 전체 구현

### DIFF
--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/PmfController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/PmfController.java
@@ -1,0 +1,104 @@
+package com.vibe.bizplan.bizplan_be.api;
+
+import com.vibe.bizplan.bizplan_be.domain.service.PmfService;
+import com.vibe.bizplan.bizplan_be.dto.request.PmfSubmitRequest;
+import com.vibe.bizplan.bizplan_be.dto.response.PmfQuestionsResponse;
+import com.vibe.bizplan.bizplan_be.dto.response.PmfReportResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * PMF(Product-Market Fit) REST API 컨트롤러.
+ * PMF 설문 질문 조회, 결과 제출, 리포트 조회 API를 제공한다.
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "PMF", description = "Product-Market Fit 진단 API")
+public class PmfController {
+
+    private final PmfService pmfService;
+
+    /**
+     * PMF 설문 질문 목록 조회.
+     *
+     * @return PMF 질문 목록
+     */
+    @GetMapping("/pmf/questions")
+    @Operation(summary = "PMF 설문 질문 조회", description = "PMF 진단용 설문 질문 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = PmfQuestionsResponse.class)))
+    })
+    public ResponseEntity<PmfQuestionsResponse> getQuestions() {
+        log.info("GET /pmf/questions");
+        PmfQuestionsResponse response = pmfService.getQuestions();
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * PMF 설문 결과 제출 및 분석.
+     *
+     * @param projectId 프로젝트 ID
+     * @param request 설문 답변
+     * @return PMF 분석 리포트
+     */
+    @PostMapping("/projects/{projectId}/pmf/submit")
+    @Operation(summary = "PMF 설문 결과 제출", description = "PMF 설문 답변을 제출하고 분석 결과를 반환합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "분석 완료",
+                    content = @Content(schema = @Schema(implementation = PmfReportResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    public ResponseEntity<PmfReportResponse> submitPmf(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Valid @RequestBody PmfSubmitRequest request
+    ) {
+        log.info("POST /projects/{}/pmf/submit - answers={}", projectId, request.answers().size());
+        PmfReportResponse response = pmfService.submitAndAnalyze(projectId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 저장된 PMF 리포트 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @return PMF 리포트 (없으면 404)
+     */
+    @GetMapping("/projects/{projectId}/pmf/report")
+    @Operation(summary = "PMF 리포트 조회", description = "저장된 PMF 분석 결과를 조회합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = PmfReportResponse.class))),
+            @ApiResponse(responseCode = "404", description = "PMF 리포트 없음")
+    })
+    public ResponseEntity<PmfReportResponse> getReport(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId
+    ) {
+        log.info("GET /projects/{}/pmf/report", projectId);
+        
+        return pmfService.getReport(projectId)
+                .map(report -> {
+                    log.info("PMF 리포트 조회 완료 - projectId={}, score={}", projectId, report.score());
+                    return ResponseEntity.ok(report);
+                })
+                .orElseGet(() -> {
+                    log.info("PMF 리포트 없음 - projectId={}", projectId);
+                    return ResponseEntity.notFound().build();
+                });
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/PmfService.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/PmfService.java
@@ -1,0 +1,279 @@
+package com.vibe.bizplan.bizplan_be.domain.service;
+
+import com.vibe.bizplan.bizplan_be.dto.request.PmfSubmitRequest;
+import com.vibe.bizplan.bizplan_be.dto.response.PmfQuestionResponse;
+import com.vibe.bizplan.bizplan_be.dto.response.PmfQuestionResponse.QuestionOption;
+import com.vibe.bizplan.bizplan_be.dto.response.PmfQuestionsResponse;
+import com.vibe.bizplan.bizplan_be.dto.response.PmfReportResponse;
+import com.vibe.bizplan.bizplan_be.dto.response.PmfReportResponse.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * PMF(Product-Market Fit) 서비스.
+ * PMF 설문 질문 제공 및 결과 분석 기능을 담당한다.
+ * MVP에서는 인메모리 저장소를 사용한다.
+ */
+@Slf4j
+@Service
+public class PmfService {
+
+    // MVP: 인메모리 저장소 (프로젝트ID -> PMF 리포트)
+    private final Map<String, PmfReportResponse> reportStore = new ConcurrentHashMap<>();
+
+    /**
+     * PMF 설문 질문 목록 조회.
+     * MVP: 하드코딩된 Sean Ellis 테스트 기반 질문.
+     *
+     * @return PMF 질문 목록
+     */
+    public PmfQuestionsResponse getQuestions() {
+        log.info("[PMF] 설문 질문 조회");
+        
+        List<PmfQuestionResponse> questions = List.of(
+                new PmfQuestionResponse(
+                        "pmf-1",
+                        "만약 이 제품을 더 이상 사용할 수 없게 된다면 어떻게 느끼시겠습니까?",
+                        "radio",
+                        true,
+                        List.of(
+                                new QuestionOption(1, "매우 실망할 것이다"),
+                                new QuestionOption(2, "다소 실망할 것이다"),
+                                new QuestionOption(3, "실망하지 않을 것이다"),
+                                new QuestionOption(4, "해당 없음 (이미 사용하지 않음)")
+                        )
+                ),
+                new PmfQuestionResponse(
+                        "pmf-2",
+                        "이 제품의 주요 혜택은 무엇입니까?",
+                        "multiselect",
+                        true,
+                        List.of(
+                                new QuestionOption(1, "시간 절약"),
+                                new QuestionOption(2, "비용 절감"),
+                                new QuestionOption(3, "품질/성능 향상"),
+                                new QuestionOption(4, "편의성 증가"),
+                                new QuestionOption(5, "기타")
+                        )
+                ),
+                new PmfQuestionResponse(
+                        "pmf-3",
+                        "이 제품을 가장 잘 설명하는 대상은 누구입니까?",
+                        "radio",
+                        true,
+                        List.of(
+                                new QuestionOption(1, "창업자/스타트업"),
+                                new QuestionOption(2, "중소기업 경영자"),
+                                new QuestionOption(3, "대기업 직원"),
+                                new QuestionOption(4, "프리랜서"),
+                                new QuestionOption(5, "기타")
+                        )
+                ),
+                new PmfQuestionResponse(
+                        "pmf-4",
+                        "이 제품을 어떻게 알게 되셨습니까?",
+                        "radio",
+                        false,
+                        List.of(
+                                new QuestionOption(1, "지인 추천"),
+                                new QuestionOption(2, "검색 엔진"),
+                                new QuestionOption(3, "소셜 미디어"),
+                                new QuestionOption(4, "광고"),
+                                new QuestionOption(5, "기타")
+                        )
+                ),
+                new PmfQuestionResponse(
+                        "pmf-5",
+                        "이 제품을 다른 사람에게 추천할 의향이 있으십니까? (0-10점)",
+                        "radio",
+                        true,
+                        List.of(
+                                new QuestionOption(0, "0 - 전혀 추천하지 않음"),
+                                new QuestionOption(1, "1"),
+                                new QuestionOption(2, "2"),
+                                new QuestionOption(3, "3"),
+                                new QuestionOption(4, "4"),
+                                new QuestionOption(5, "5"),
+                                new QuestionOption(6, "6"),
+                                new QuestionOption(7, "7"),
+                                new QuestionOption(8, "8"),
+                                new QuestionOption(9, "9"),
+                                new QuestionOption(10, "10 - 적극 추천")
+                        )
+                )
+        );
+        
+        return new PmfQuestionsResponse(questions);
+    }
+
+    /**
+     * PMF 설문 결과 제출 및 분석.
+     *
+     * @param projectId 프로젝트 ID
+     * @param request 설문 답변
+     * @return PMF 분석 리포트
+     */
+    public PmfReportResponse submitAndAnalyze(String projectId, PmfSubmitRequest request) {
+        log.info("[PMF] 설문 결과 제출 - projectId={}, answers={}", projectId, request.answers().size());
+        
+        // PMF 점수 계산
+        int score = calculatePmfScore(request);
+        String level = determinePmfLevel(score);
+        
+        // 리스크 및 추천사항 생성
+        List<Risk> risks = generateRisks(score, request);
+        List<Recommendation> recommendations = generateRecommendations(score, request);
+        
+        // 답변 변환
+        List<PmfAnswer> answers = request.answers().stream()
+                .map(a -> new PmfAnswer(a.questionId(), a.value()))
+                .toList();
+        
+        PmfReportResponse report = new PmfReportResponse(
+                projectId,
+                score,
+                level,
+                risks,
+                recommendations,
+                answers,
+                LocalDateTime.now()
+        );
+        
+        // 저장
+        reportStore.put(projectId, report);
+        
+        log.info("[PMF] 분석 완료 - projectId={}, score={}, level={}", projectId, score, level);
+        return report;
+    }
+
+    /**
+     * 저장된 PMF 리포트 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @return PMF 리포트 (Optional)
+     */
+    public Optional<PmfReportResponse> getReport(String projectId) {
+        log.info("[PMF] 리포트 조회 - projectId={}", projectId);
+        return Optional.ofNullable(reportStore.get(projectId));
+    }
+
+    /**
+     * PMF 점수 계산.
+     * Sean Ellis 테스트: "매우 실망할 것이다" 비율이 40% 이상이면 PMF 달성.
+     */
+    private int calculatePmfScore(PmfSubmitRequest request) {
+        // pmf-1 질문의 답변 확인 (핵심 질문)
+        Optional<Object> pmf1Answer = request.answers().stream()
+                .filter(a -> "pmf-1".equals(a.questionId()))
+                .map(PmfSubmitRequest.PmfAnswerRequest::value)
+                .findFirst();
+        
+        int baseScore = 25; // 기본 점수
+        
+        if (pmf1Answer.isPresent()) {
+            Object value = pmf1Answer.get();
+            int answerValue = value instanceof Number ? ((Number) value).intValue() : 3;
+            
+            // 1 = 매우 실망 (높은 점수), 4 = 해당 없음 (낮은 점수)
+            baseScore = switch (answerValue) {
+                case 1 -> 45; // 매우 실망 -> 높은 PMF
+                case 2 -> 30; // 다소 실망 -> 중간 PMF
+                case 3 -> 15; // 실망하지 않음 -> 낮은 PMF
+                default -> 10; // 해당 없음
+            };
+        }
+        
+        // NPS 질문 (pmf-5) 보너스 점수
+        Optional<Object> npsAnswer = request.answers().stream()
+                .filter(a -> "pmf-5".equals(a.questionId()))
+                .map(PmfSubmitRequest.PmfAnswerRequest::value)
+                .findFirst();
+        
+        if (npsAnswer.isPresent()) {
+            Object value = npsAnswer.get();
+            int nps = value instanceof Number ? ((Number) value).intValue() : 5;
+            if (nps >= 9) baseScore += 10; // Promoter 보너스
+            else if (nps >= 7) baseScore += 5; // Passive 보너스
+        }
+        
+        return Math.min(100, baseScore);
+    }
+
+    /**
+     * PMF 레벨 결정.
+     */
+    private String determinePmfLevel(int score) {
+        if (score >= 40) return "excellent";
+        if (score >= 30) return "high";
+        if (score >= 20) return "medium";
+        return "low";
+    }
+
+    /**
+     * 리스크 생성.
+     */
+    private List<Risk> generateRisks(int score, PmfSubmitRequest request) {
+        List<Risk> risks = new ArrayList<>();
+        
+        if (score < 40) {
+            risks.add(new Risk(
+                    "risk-1",
+                    "PMF 미달성",
+                    "현재 제품이 시장의 핵심 니즈를 충족하지 못하고 있습니다.",
+                    score < 20 ? "high" : "medium"
+            ));
+        }
+        
+        if (score < 30) {
+            risks.add(new Risk(
+                    "risk-2",
+                    "시장 검증 필요",
+                    "더 많은 고객 피드백과 시장 검증이 필요합니다.",
+                    "medium"
+            ));
+        }
+        
+        return risks;
+    }
+
+    /**
+     * 추천사항 생성.
+     */
+    private List<Recommendation> generateRecommendations(int score, PmfSubmitRequest request) {
+        List<Recommendation> recommendations = new ArrayList<>();
+        
+        if (score < 40) {
+            recommendations.add(new Recommendation(
+                    "rec-1",
+                    "고객 인터뷰 진행",
+                    "핵심 고객층과 심층 인터뷰를 통해 제품 개선점을 파악하세요.",
+                    "high"
+            ));
+        }
+        
+        if (score < 30) {
+            recommendations.add(new Recommendation(
+                    "rec-2",
+                    "MVP 피벗 고려",
+                    "현재 접근 방식이 효과적이지 않을 수 있습니다. 피벗을 고려해보세요.",
+                    "high"
+            ));
+        }
+        
+        if (score >= 40) {
+            recommendations.add(new Recommendation(
+                    "rec-3",
+                    "스케일업 준비",
+                    "PMF가 달성되었습니다. 마케팅 확대와 성장 전략을 수립하세요.",
+                    "medium"
+            ));
+        }
+        
+        return recommendations;
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/PmfSubmitRequest.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/PmfSubmitRequest.java
@@ -1,0 +1,25 @@
+package com.vibe.bizplan.bizplan_be.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/**
+ * PMF 설문 결과 제출 요청 DTO.
+ */
+public record PmfSubmitRequest(
+        /** 설문 답변 목록 */
+        @NotEmpty(message = "답변 목록은 필수입니다")
+        List<PmfAnswerRequest> answers
+) {
+    /**
+     * 개별 답변.
+     */
+    public record PmfAnswerRequest(
+            /** 질문 ID */
+            String questionId,
+            /** 답변 값 (단일 값 또는 배열) */
+            Object value
+    ) {}
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/PmfQuestionResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/PmfQuestionResponse.java
@@ -1,0 +1,34 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import java.util.List;
+
+/**
+ * PMF 설문 질문 응답 DTO.
+ */
+public record PmfQuestionResponse(
+        /** 질문 ID */
+        String id,
+        
+        /** 질문 내용 */
+        String question,
+        
+        /** 질문 유형 (radio, multiselect, textarea) */
+        String type,
+        
+        /** 필수 여부 */
+        boolean required,
+        
+        /** 선택 옵션 목록 */
+        List<QuestionOption> options
+) {
+    /**
+     * 질문 선택 옵션.
+     */
+    public record QuestionOption(
+            /** 옵션 값 */
+            int value,
+            /** 옵션 라벨 */
+            String label
+    ) {}
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/PmfQuestionsResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/PmfQuestionsResponse.java
@@ -1,0 +1,13 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import java.util.List;
+
+/**
+ * PMF 설문 질문 목록 응답 DTO.
+ */
+public record PmfQuestionsResponse(
+        /** 질문 목록 */
+        List<PmfQuestionResponse> questions
+) {
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/PmfReportResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/PmfReportResponse.java
@@ -1,0 +1,59 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * PMF 리포트 응답 DTO.
+ */
+public record PmfReportResponse(
+        /** 프로젝트 ID */
+        String projectId,
+        
+        /** PMF 점수 (0-100) */
+        int score,
+        
+        /** PMF 레벨 (excellent, high, medium, low) */
+        String level,
+        
+        /** 리스크 목록 */
+        List<Risk> risks,
+        
+        /** 추천사항 목록 */
+        List<Recommendation> recommendations,
+        
+        /** 설문 답변 목록 */
+        List<PmfAnswer> answers,
+        
+        /** 생성일시 */
+        LocalDateTime createdAt
+) {
+    /**
+     * PMF 리스크.
+     */
+    public record Risk(
+            String id,
+            String title,
+            String description,
+            String severity  // high, medium, low
+    ) {}
+    
+    /**
+     * PMF 추천사항.
+     */
+    public record Recommendation(
+            String id,
+            String title,
+            String description,
+            String priority  // high, medium, low
+    ) {}
+    
+    /**
+     * PMF 설문 답변.
+     */
+    public record PmfAnswer(
+            String questionId,
+            Object value
+    ) {}
+}
+


### PR DESCRIPTION
## 📋 요약
PMF(Product-Market Fit) 진단 관련 3개 API 전체 구현

## 🎯 변경사항

### [BE-API-006] PMF 설문 질문 조회
- `GET /pmf/questions` 엔드포인트
- Sean Ellis 테스트 기반 5개 질문

### [BE-API-007] PMF 설문 결과 제출
- `POST /projects/{projectId}/pmf/submit` 엔드포인트
- PMF 점수 계산 및 레벨 판정
- 리스크 및 추천사항 자동 생성

### [BE-API-008] PMF 리포트 조회
- `GET /projects/{projectId}/pmf/report` 엔드포인트
- 저장된 PMF 분석 결과 조회

## 📝 PMF 레벨 정의
| Level | Score | 설명 |
|-------|-------|------|
| excellent | 40%+ | PMF 달성 |
| high | 30-39% | 거의 달성 |
| medium | 20-29% | 개선 필요 |
| low | <20% | PMF 미달성 |

Closes #53, Closes #54, Closes #55