### PR TITLE
[BE-AI-001] 사업계획서 섹션 AI 생성 API 연동

### DIFF
--- a/scripts/create-api-issues.sh
+++ b/scripts/create-api-issues.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# ============================================
+# GitHub Issue 생성 스크립트
+# BE-API-REQUEST.md 기반 API 개발 이슈 등록
+# ============================================
+# 사용법: ./scripts/create-api-issues.sh
+# 사전 요구사항: gh auth login 완료
+# ============================================
+
+set -e
+
+# 색상 정의
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "============================================"
+echo " 🚀 BE API 개발 이슈 등록 스크립트"
+echo "============================================"
+
+# GitHub 인증 확인
+if ! gh auth status &>/dev/null; then
+    echo -e "${RED}❌ GitHub CLI 인증이 필요합니다.${NC}"
+    echo "다음 명령어로 인증하세요: gh auth login"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ GitHub 인증 확인 완료${NC}"
+echo ""
+
+# 프로젝트 디렉토리
+TASKS_DIR="tasks/functional"
+
+# 이슈 생성 함수
+create_issue() {
+    local file=$1
+    local title=$2
+    local labels=$3
+    
+    if [ -f "$TASKS_DIR/$file" ]; then
+        echo -e "${YELLOW}📝 이슈 생성 중: $title${NC}"
+        gh issue create \
+            --title "$title" \
+            --body-file "$TASKS_DIR/$file" \
+            --label "$labels"
+        echo -e "${GREEN}✅ 완료: $title${NC}"
+        echo ""
+        sleep 1  # Rate limiting 방지
+    else
+        echo -e "${RED}❌ 파일 없음: $TASKS_DIR/$file${NC}"
+    fi
+}
+
+echo "============================================"
+echo " 🔴 High Priority Issues (프로젝트 수정/삭제)"
+echo "============================================"
+
+create_issue "BE-API-001-project-update.md" \
+    "[BE-API-001] 프로젝트 수정 API 구현" \
+    "priority-high,feature,backend,api"
+
+create_issue "BE-API-002-project-delete.md" \
+    "[BE-API-002] 프로젝트 삭제 API 구현" \
+    "priority-high,feature,backend,api"
+
+echo "============================================"
+echo " 🟠 Medium Priority Issues (위저드/재무)"
+echo "============================================"
+
+create_issue "BE-API-003-wizard-steps.md" \
+    "[BE-API-003] 위저드 단계 정의 조회 API 구현" \
+    "priority-medium,feature,backend,api"
+
+create_issue "BE-API-004-financials-get.md" \
+    "[BE-API-004] 재무 데이터 조회 API 구현" \
+    "priority-medium,feature,backend,api"
+
+create_issue "BE-API-005-financials-save.md" \
+    "[BE-API-005] 재무 데이터 저장 API 구현" \
+    "priority-medium,feature,backend,api"
+
+echo "============================================"
+echo " 🟡 Low Priority Issues (PMF)"
+echo "============================================"
+
+create_issue "BE-API-006-pmf-questions.md" \
+    "[BE-API-006] PMF 설문 질문 조회 API 구현" \
+    "priority-low,feature,backend,api"
+
+create_issue "BE-API-007-pmf-submit.md" \
+    "[BE-API-007] PMF 설문 결과 제출 API 구현" \
+    "priority-low,feature,backend,api"
+
+create_issue "BE-API-008-pmf-report.md" \
+    "[BE-API-008] PMF 리포트 조회 API 구현" \
+    "priority-low,feature,backend,api"
+
+echo "============================================"
+echo -e "${GREEN}🎉 모든 이슈가 성공적으로 생성되었습니다!${NC}"
+echo "============================================"
+echo ""
+echo "📋 생성된 이슈 목록 확인:"
+gh issue list --limit 10
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/BizPlanSectionController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/BizPlanSectionController.java
@@ -1,0 +1,182 @@
+package com.vibe.bizplan.bizplan_be.api;
+
+import com.vibe.bizplan.bizplan_be.domain.entity.User;
+import com.vibe.bizplan.bizplan_be.domain.service.BizPlanSectionService;
+import com.vibe.bizplan.bizplan_be.dto.request.GenerateSectionRequest;
+import com.vibe.bizplan.bizplan_be.dto.request.UpdateSectionRequest;
+import com.vibe.bizplan.bizplan_be.dto.response.BizPlanSectionResponse;
+import com.vibe.bizplan.bizplan_be.dto.response.BizPlanSectionsListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 사업계획서 섹션 관리 REST API 컨트롤러.
+ * AI를 통한 섹션 생성 및 CRUD 기능을 제공한다.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/projects/{projectId}/bizplan/sections")
+@RequiredArgsConstructor
+@Tag(name = "BizPlan Sections", description = "사업계획서 섹션 AI 생성 및 관리 API")
+@SecurityRequirement(name = "bearerAuth")
+public class BizPlanSectionController {
+
+    private final BizPlanSectionService sectionService;
+
+    /**
+     * AI를 통해 특정 섹션 생성.
+     *
+     * @param projectId   프로젝트 ID
+     * @param sectionType 섹션 타입
+     * @param request     생성 요청 (선택)
+     * @return 생성된 섹션 응답
+     */
+    @PostMapping("/{sectionType}/generate")
+    @Operation(
+            summary = "AI 섹션 생성",
+            description = "AI Engine을 통해 사업계획서 특정 섹션을 생성합니다. " +
+                    "Wizard 답변을 기반으로 내용을 생성하며, 이전 섹션의 내용도 참고합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "생성 성공",
+                    content = @Content(schema = @Schema(implementation = BizPlanSectionResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 섹션 타입"),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "AI 엔진 오류")
+    })
+    public ResponseEntity<BizPlanSectionResponse> generateSection(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Parameter(description = "섹션 타입 (executive_summary, problem_definition 등)")
+            @PathVariable String sectionType,
+            @Valid @RequestBody(required = false) GenerateSectionRequest request,
+            @AuthenticationPrincipal User user
+    ) {
+        log.info("POST /projects/{}/bizplan/sections/{}/generate - userId={}",
+                projectId, sectionType, user != null ? user.getId() : "anonymous");
+
+        BizPlanSectionResponse response = sectionService.generateSection(projectId, sectionType, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 프로젝트의 모든 섹션 목록 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 섹션 목록
+     */
+    @GetMapping
+    @Operation(
+            summary = "섹션 목록 조회",
+            description = "프로젝트에 저장된 모든 사업계획서 섹션 목록을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = BizPlanSectionsListResponse.class))),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public ResponseEntity<BizPlanSectionsListResponse> getSections(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId
+    ) {
+        log.info("GET /projects/{}/bizplan/sections", projectId);
+
+        BizPlanSectionsListResponse response = sectionService.getSections(projectId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 특정 섹션 조회.
+     *
+     * @param projectId   프로젝트 ID
+     * @param sectionType 섹션 타입
+     * @return 섹션 응답
+     */
+    @GetMapping("/{sectionType}")
+    @Operation(
+            summary = "섹션 조회",
+            description = "특정 섹션의 내용을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = BizPlanSectionResponse.class))),
+            @ApiResponse(responseCode = "404", description = "섹션을 찾을 수 없음")
+    })
+    public ResponseEntity<BizPlanSectionResponse> getSection(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Parameter(description = "섹션 타입") @PathVariable String sectionType
+    ) {
+        log.info("GET /projects/{}/bizplan/sections/{}", projectId, sectionType);
+
+        return sectionService.getSection(projectId, sectionType)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * 섹션 내용 수동 업데이트.
+     *
+     * @param projectId   프로젝트 ID
+     * @param sectionType 섹션 타입
+     * @param request     업데이트 요청
+     * @return 업데이트된 섹션 응답
+     */
+    @PutMapping("/{sectionType}")
+    @Operation(
+            summary = "섹션 수정",
+            description = "섹션의 제목과 내용을 수동으로 수정합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = BizPlanSectionResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public ResponseEntity<BizPlanSectionResponse> updateSection(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Parameter(description = "섹션 타입") @PathVariable String sectionType,
+            @Valid @RequestBody UpdateSectionRequest request
+    ) {
+        log.info("PUT /projects/{}/bizplan/sections/{}", projectId, sectionType);
+
+        BizPlanSectionResponse response = sectionService.updateSection(projectId, sectionType, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 섹션 삭제.
+     *
+     * @param projectId   프로젝트 ID
+     * @param sectionType 섹션 타입
+     * @return 204 No Content
+     */
+    @DeleteMapping("/{sectionType}")
+    @Operation(
+            summary = "섹션 삭제",
+            description = "특정 섹션을 삭제합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public ResponseEntity<Void> deleteSection(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Parameter(description = "섹션 타입") @PathVariable String sectionType
+    ) {
+        log.info("DELETE /projects/{}/bizplan/sections/{}", projectId, sectionType);
+
+        sectionService.deleteSection(projectId, sectionType);
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/config/OpenApiConfig.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/config/OpenApiConfig.java
@@ -1,0 +1,120 @@
+package com.vibe.bizplan.bizplan_be.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.tags.Tag;
+
+/**
+ * OpenAPI (Swagger) 문서 설정.
+ * API 문서화를 위한 메타데이터, 보안 스키마, 태그 그룹을 정의한다.
+ */
+@Configuration
+public class OpenApiConfig {
+
+    @Value("${server.port:8080}")
+    private int serverPort;
+
+    /**
+     * OpenAPI 문서 설정 빈.
+     * JWT Bearer 인증, API 메타데이터, 태그 그룹을 설정한다.
+     */
+    @Bean
+    public OpenAPI customOpenAPI() {
+        // JWT Bearer 인증 스키마 정의
+        final String securitySchemeName = "bearerAuth";
+        
+        return new OpenAPI()
+                // API 기본 정보
+                .info(apiInfo())
+                
+                // 서버 정보
+                .servers(List.of(
+                        new Server()
+                                .url("http://localhost:" + serverPort)
+                                .description("로컬 개발 서버"),
+                        new Server()
+                                .url("https://api.bizplan.vibe.com")
+                                .description("운영 서버 (예정)")
+                ))
+                
+                // 보안 스키마 컴포넌트 등록
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                                .name(securitySchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("JWT 액세스 토큰을 입력하세요. (예: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...)")
+                        )
+                )
+                
+                // 전역 보안 요구사항 (인증이 필요한 API에 자동 적용)
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                
+                // API 태그 그룹 정의 (정렬 순서)
+                .tags(List.of(
+                        new Tag().name("Auth").description("🔐 인증 API - 회원가입, 로그인, 토큰 갱신"),
+                        new Tag().name("Users").description("👤 사용자 관리 API - 프로필 조회/수정, 비밀번호 변경"),
+                        new Tag().name("Projects").description("📁 프로젝트 관리 API - 프로젝트 생성, 조회, 템플릿"),
+                        new Tag().name("Wizard").description("🧙 위자드 API - 단계별 답변 저장/조회"),
+                        new Tag().name("Business Plan Documents").description("📄 사업계획서 API - 문서 생성, 섹션 재생성"),
+                        new Tag().name("Document Export").description("📥 내보내기 API - PDF/HTML 다운로드"),
+                        new Tag().name("Financials").description("💰 재무 추정 API - 손익계산, 유닛 이코노믹스"),
+                        new Tag().name("Financials Preview").description("🔮 재무 미리보기 API - 프로젝트 미연동 계산")
+                ));
+    }
+
+    /**
+     * API 기본 정보 설정.
+     */
+    private Info apiInfo() {
+        return new Info()
+                .title("BizPlan API")
+                .description("""
+                        ## 🚀 AI Co-Pilot for First-time Founders
+                        
+                        창업자를 위한 AI 사업계획서 자동 생성 플랫폼의 백엔드 API입니다.
+                        
+                        ### 주요 기능
+                        - **Wizard 입력**: 단계별 질문 응답으로 사업 정보 수집
+                        - **AI 문서 생성**: LLM 기반 사업계획서 초안 자동 생성
+                        - **재무 추정**: 핵심 변수 기반 3년 손익/현금흐름 계산
+                        - **문서 내보내기**: PDF/HTML 형식 다운로드
+                        
+                        ### 인증 방식
+                        - JWT Bearer Token 인증
+                        - Access Token (1시간) + Refresh Token (7일)
+                        
+                        ### 에러 응답 형식
+                        ```json
+                        {
+                          "timestamp": "2025-01-01T12:00:00",
+                          "status": 400,
+                          "error": "Bad Request",
+                          "message": "에러 메시지",
+                          "path": "/api/v1/..."
+                        }
+                        ```
+                        """)
+                .version("v1.0.0")
+                .contact(new Contact()
+                        .name("BizPlan Team")
+                        .email("support@bizplan.vibe.com")
+                        .url("https://bizplan.vibe.com"))
+                .license(new License()
+                        .name("Private License")
+                        .url("https://bizplan.vibe.com/license"));
+    }
+}

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/entity/BizPlanSection.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/entity/BizPlanSection.java
@@ -1,0 +1,120 @@
+package com.vibe.bizplan.bizplan_be.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 사업계획서 섹션 엔티티.
+ * AI 생성 섹션 내용을 저장한다.
+ */
+@Entity
+@Table(name = "bizplan_sections",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_project_section",
+                columnNames = {"project_id", "section_type"}
+        ))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BizPlanSection {
+
+    /** 섹션 ID */
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    /** 프로젝트 ID */
+    @Column(name = "project_id", nullable = false, length = 36)
+    private String projectId;
+
+    /** 섹션 타입 (executive_summary, problem_definition 등) */
+    @Column(name = "section_type", nullable = false, length = 50)
+    private String sectionType;
+
+    /** 섹션 제목 */
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    /** 섹션 내용 */
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    /** 글자 수 */
+    @Column(name = "word_count")
+    private Integer wordCount;
+
+    /** 사용된 AI 모델 */
+    @Column(name = "model_used", length = 100)
+    private String modelUsed;
+
+    /** 생성 소요 시간 (ms) */
+    @Column(name = "generation_time_ms")
+    private Integer generationTimeMs;
+
+    /** 생성일시 */
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 수정일시 */
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    /**
+     * 섹션 생성 팩토리 메서드.
+     */
+    public static BizPlanSection create(
+            String projectId,
+            String sectionType,
+            String title,
+            String content,
+            Integer wordCount,
+            String modelUsed,
+            Integer generationTimeMs
+    ) {
+        BizPlanSection section = new BizPlanSection();
+        section.id = UUID.randomUUID().toString();
+        section.projectId = projectId;
+        section.sectionType = sectionType;
+        section.title = title;
+        section.content = content;
+        section.wordCount = wordCount;
+        section.modelUsed = modelUsed;
+        section.generationTimeMs = generationTimeMs;
+        return section;
+    }
+
+    /**
+     * 섹션 내용 업데이트.
+     */
+    public void updateContent(String title, String content) {
+        this.title = title;
+        this.content = content;
+        this.wordCount = content != null ? content.length() : 0;
+    }
+
+    /**
+     * AI 생성 결과로 업데이트.
+     */
+    public void updateFromAi(
+            String title,
+            String content,
+            Integer wordCount,
+            String modelUsed,
+            Integer generationTimeMs
+    ) {
+        this.title = title;
+        this.content = content;
+        this.wordCount = wordCount;
+        this.modelUsed = modelUsed;
+        this.generationTimeMs = generationTimeMs;
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/BizPlanSectionService.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/BizPlanSectionService.java
@@ -1,0 +1,289 @@
+package com.vibe.bizplan.bizplan_be.domain.service;
+
+import com.vibe.bizplan.bizplan_be.domain.entity.BizPlanSection;
+import com.vibe.bizplan.bizplan_be.domain.entity.Project;
+import com.vibe.bizplan.bizplan_be.domain.exception.ProjectNotFoundException;
+import com.vibe.bizplan.bizplan_be.domain.model.SectionType;
+import com.vibe.bizplan.bizplan_be.domain.service.util.JsonParsingUtil;
+import com.vibe.bizplan.bizplan_be.dto.request.GenerateSectionRequest;
+import com.vibe.bizplan.bizplan_be.dto.request.UpdateSectionRequest;
+import com.vibe.bizplan.bizplan_be.dto.response.BizPlanSectionResponse;
+import com.vibe.bizplan.bizplan_be.dto.response.BizPlanSectionsListResponse;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.AiEngineClient;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.BizPlanGenerateRequest;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.BizPlanGenerateResponse;
+import com.vibe.bizplan.bizplan_be.infrastructure.repository.BizPlanSectionRepository;
+import com.vibe.bizplan.bizplan_be.infrastructure.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+/**
+ * 사업계획서 섹션 서비스.
+ * 개별 섹션의 AI 생성, CRUD, 조회를 담당한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BizPlanSectionService {
+
+    private final ProjectRepository projectRepository;
+    private final BizPlanSectionRepository sectionRepository;
+    private final AiEngineClient aiEngineClient;
+    private final JsonParsingUtil jsonParsingUtil;
+
+    /**
+     * AI를 통해 특정 섹션을 생성한다.
+     *
+     * @param projectId   프로젝트 ID
+     * @param sectionType 섹션 타입 코드
+     * @param request     생성 요청 DTO
+     * @return 생성된 섹션 응답
+     */
+    @Transactional
+    public BizPlanSectionResponse generateSection(String projectId, String sectionType, GenerateSectionRequest request) {
+        Objects.requireNonNull(projectId, "프로젝트 ID는 필수입니다");
+        Objects.requireNonNull(sectionType, "섹션 타입은 필수입니다");
+        long startTime = System.currentTimeMillis();
+        log.info("[BizPlanSection] 섹션 생성 시작 - projectId={}, sectionType={}, mode={}",
+                projectId, sectionType, request != null ? request.getMode() : "easy");
+
+        // 섹션 타입 유효성 검증
+        SectionType section = SectionType.fromCode(sectionType)
+                .orElseThrow(() -> {
+                    log.error("[BizPlanSection] 유효하지 않은 섹션 타입 - sectionType={}", sectionType);
+                    return new IllegalArgumentException("유효하지 않은 섹션 타입입니다: " + sectionType);
+                });
+
+        // 프로젝트 조회
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> {
+                    log.error("[BizPlanSection] 프로젝트 조회 실패 - projectId={}", projectId);
+                    return new ProjectNotFoundException(projectId);
+                });
+
+        String templateCode = project.getTemplateCode().name();
+
+        // Wizard 답변 파싱
+        Map<String, Object> context = jsonParsingUtil.parseToImmutableMap(project.getWizardAnswers());
+        log.debug("[BizPlanSection] 컨텍스트 준비 완료 - contextKeys={}", context.keySet());
+
+        // 이전 섹션 내용 조회 (일관성 유지용)
+        Map<String, String> previousSections = getPreviousSectionsContent(projectId, section);
+
+        // AI Engine 요청 생성
+        String mode = request != null && request.mode() != null ? request.mode() : "easy";
+        String additionalInstructions = request != null ? request.additionalInstructions() : null;
+
+        BizPlanGenerateRequest aiRequest = new BizPlanGenerateRequest(
+                projectId,
+                templateCode,
+                sectionType,
+                mode,
+                context,
+                previousSections,
+                additionalInstructions
+        );
+
+        // AI Engine 호출
+        log.debug("[BizPlanSection] AI 엔진 호출 중 - projectId={}, sectionType={}", projectId, sectionType);
+        BizPlanGenerateResponse aiResponse = aiEngineClient.generateSection(aiRequest);
+
+        // 결과 저장
+        BizPlanSection savedSection = saveOrUpdateSection(projectId, sectionType, aiResponse);
+
+        long duration = System.currentTimeMillis() - startTime;
+        log.info("[BizPlanSection] 섹션 생성 완료 - projectId={}, sectionType={}, wordCount={}, duration={}ms",
+                projectId, sectionType,
+                savedSection != null ? savedSection.getWordCount() : 0, duration);
+
+        // 응답 생성
+        return BizPlanSectionResponse.fromAiResult(
+                savedSection,
+                aiResponse != null ? aiResponse.suggestions() : null,
+                aiResponse != null ? aiResponse.consistencyWarnings() : null
+        );
+    }
+
+    /**
+     * 프로젝트의 모든 섹션 목록 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 섹션 목록 응답
+     */
+    @Transactional(readOnly = true)
+    public BizPlanSectionsListResponse getSections(String projectId) {
+        Objects.requireNonNull(projectId, "프로젝트 ID는 필수입니다");
+        log.debug("[BizPlanSection] 섹션 목록 조회 - projectId={}", projectId);
+
+        // 프로젝트 존재 여부 확인
+        if (!projectRepository.existsById(projectId)) {
+            throw new ProjectNotFoundException(projectId);
+        }
+
+        List<BizPlanSection> sections = sectionRepository.findByProjectIdOrderBySectionType(projectId);
+        List<BizPlanSectionsListResponse.SectionSummary> summaries = sections.stream()
+                .map(s -> new BizPlanSectionsListResponse.SectionSummary(
+                        s.getSectionType(),
+                        s.getTitle(),
+                        s.getWordCount(),
+                        s.getUpdatedAt()
+                ))
+                .toList();
+
+        log.debug("[BizPlanSection] 섹션 목록 조회 완료 - projectId={}, count={}", projectId, summaries.size());
+
+        return BizPlanSectionsListResponse.of(projectId, summaries);
+    }
+
+    /**
+     * 특정 섹션 조회.
+     *
+     * @param projectId   프로젝트 ID
+     * @param sectionType 섹션 타입
+     * @return 섹션 응답 (Optional)
+     */
+    @Transactional(readOnly = true)
+    public Optional<BizPlanSectionResponse> getSection(String projectId, String sectionType) {
+        Objects.requireNonNull(projectId, "프로젝트 ID는 필수입니다");
+        Objects.requireNonNull(sectionType, "섹션 타입은 필수입니다");
+        log.debug("[BizPlanSection] 섹션 조회 - projectId={}, sectionType={}", projectId, sectionType);
+
+        return sectionRepository.findByProjectIdAndSectionType(projectId, sectionType)
+                .map(section -> {
+                    log.debug("[BizPlanSection] 섹션 조회 완료 - projectId={}, sectionType={}", projectId, sectionType);
+                    return BizPlanSectionResponse.from(section);
+                });
+    }
+
+    /**
+     * 섹션 내용 수동 업데이트.
+     *
+     * @param projectId   프로젝트 ID
+     * @param sectionType 섹션 타입
+     * @param request     업데이트 요청
+     * @return 업데이트된 섹션 응답
+     */
+    @Transactional
+    public BizPlanSectionResponse updateSection(String projectId, String sectionType, UpdateSectionRequest request) {
+        Objects.requireNonNull(projectId, "프로젝트 ID는 필수입니다");
+        Objects.requireNonNull(sectionType, "섹션 타입은 필수입니다");
+        Objects.requireNonNull(request, "요청 데이터는 필수입니다");
+        log.info("[BizPlanSection] 섹션 수동 업데이트 - projectId={}, sectionType={}", projectId, sectionType);
+
+        // 프로젝트 존재 확인
+        if (!projectRepository.existsById(projectId)) {
+            throw new ProjectNotFoundException(projectId);
+        }
+
+        // 기존 섹션 조회 또는 새로 생성
+        BizPlanSection section = sectionRepository.findByProjectIdAndSectionType(projectId, sectionType)
+                .orElseGet(() -> {
+                    log.debug("[BizPlanSection] 새 섹션 생성 - projectId={}, sectionType={}", projectId, sectionType);
+                    return BizPlanSection.create(
+                            projectId,
+                            sectionType,
+                            request.title() != null ? request.title() : sectionType,
+                            request.content(),
+                            request.content() != null ? request.content().length() : 0,
+                            null,
+                            null
+                    );
+                });
+
+        // 내용 업데이트
+        String title = request.title() != null ? request.title() : section.getTitle();
+        section.updateContent(title, request.content());
+
+        BizPlanSection savedSection = sectionRepository.save(section);
+        log.info("[BizPlanSection] 섹션 업데이트 완료 - projectId={}, sectionType={}", projectId, sectionType);
+
+        return BizPlanSectionResponse.from(savedSection);
+    }
+
+    /**
+     * 섹션 삭제.
+     *
+     * @param projectId   프로젝트 ID
+     * @param sectionType 섹션 타입
+     */
+    @Transactional
+    public void deleteSection(String projectId, String sectionType) {
+        Objects.requireNonNull(projectId, "프로젝트 ID는 필수입니다");
+        Objects.requireNonNull(sectionType, "섹션 타입은 필수입니다");
+        log.info("[BizPlanSection] 섹션 삭제 - projectId={}, sectionType={}", projectId, sectionType);
+
+        sectionRepository.deleteByProjectIdAndSectionType(projectId, sectionType);
+        log.info("[BizPlanSection] 섹션 삭제 완료 - projectId={}, sectionType={}", projectId, sectionType);
+    }
+
+    // ==========================================
+    // Private Helper Methods
+    // ==========================================
+
+    /**
+     * AI 응답으로 섹션 저장 또는 업데이트.
+     */
+    private BizPlanSection saveOrUpdateSection(String projectId, String sectionType, BizPlanGenerateResponse response) {
+        if (response == null || response.section() == null) {
+            log.warn("[BizPlanSection] AI 응답 없음 - projectId={}, sectionType={}", projectId, sectionType);
+            return null;
+        }
+
+        BizPlanGenerateResponse.BizPlanSection aiSection = response.section();
+
+        // 기존 섹션 조회
+        Optional<BizPlanSection> existingOpt = sectionRepository.findByProjectIdAndSectionType(projectId, sectionType);
+
+        BizPlanSection section;
+        if (existingOpt.isPresent()) {
+            section = existingOpt.get();
+            section.updateFromAi(
+                    aiSection.title(),
+                    aiSection.content(),
+                    aiSection.wordCount(),
+                    aiSection.modelUsed(),
+                    aiSection.generationTimeMs()
+            );
+            log.debug("[BizPlanSection] 기존 섹션 업데이트 - projectId={}, sectionType={}", projectId, sectionType);
+        } else {
+            section = BizPlanSection.create(
+                    projectId,
+                    sectionType,
+                    aiSection.title(),
+                    aiSection.content(),
+                    aiSection.wordCount(),
+                    aiSection.modelUsed(),
+                    aiSection.generationTimeMs()
+            );
+            log.debug("[BizPlanSection] 새 섹션 생성 - projectId={}, sectionType={}", projectId, sectionType);
+        }
+
+        return sectionRepository.save(section);
+    }
+
+    /**
+     * 현재 섹션 이전의 모든 섹션 내용 조회.
+     */
+    private Map<String, String> getPreviousSectionsContent(String projectId, SectionType currentSection) {
+        Map<String, String> previous = new LinkedHashMap<>();
+
+        List<SectionType> orderedSections = SectionType.getOrderedSections();
+        for (SectionType section : orderedSections) {
+            if (section == currentSection) break;
+
+            sectionRepository.findByProjectIdAndSectionType(projectId, section.getCode())
+                    .ifPresent(s -> {
+                        if (s.getContent() != null && !s.getContent().isBlank()) {
+                            previous.put(section.getCode(), s.getContent());
+                        }
+                    });
+        }
+
+        return previous;
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/GenerateSectionRequest.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/GenerateSectionRequest.java
@@ -1,0 +1,36 @@
+package com.vibe.bizplan.bizplan_be.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * 섹션 생성 요청 DTO.
+ * 클라이언트에서 AI 섹션 생성을 요청할 때 사용.
+ */
+@Schema(description = "사업계획서 섹션 AI 생성 요청")
+public record GenerateSectionRequest(
+
+        /** 생성 모드 (easy/expert) */
+        @Schema(description = "생성 모드", example = "easy", allowableValues = {"easy", "expert"})
+        @Pattern(regexp = "^(easy|expert)$", message = "모드는 'easy' 또는 'expert'만 가능합니다")
+        String mode,
+
+        /** 추가 지시사항 */
+        @Schema(description = "AI에게 전달할 추가 지시사항", example = "기술적인 내용을 더 강조해주세요")
+        String additionalInstructions
+) {
+    /**
+     * 기본값 적용 팩토리 메서드.
+     */
+    public static GenerateSectionRequest withDefaults() {
+        return new GenerateSectionRequest("easy", null);
+    }
+
+    /**
+     * 모드 반환 (기본값 easy).
+     */
+    public String getMode() {
+        return mode != null ? mode : "easy";
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/UpdateSectionRequest.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/UpdateSectionRequest.java
@@ -1,0 +1,25 @@
+package com.vibe.bizplan.bizplan_be.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 섹션 수정 요청 DTO.
+ */
+@Schema(description = "사업계획서 섹션 수정 요청")
+public record UpdateSectionRequest(
+
+        /** 섹션 제목 */
+        @Schema(description = "섹션 제목", example = "사업개요")
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 255, message = "제목은 255자 이내여야 합니다")
+        String title,
+
+        /** 섹션 내용 */
+        @Schema(description = "섹션 내용")
+        @NotBlank(message = "내용은 필수입니다")
+        String content
+) {
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/BizPlanSectionResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/BizPlanSectionResponse.java
@@ -1,0 +1,95 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import com.vibe.bizplan.bizplan_be.domain.entity.BizPlanSection;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 사업계획서 섹션 응답 DTO.
+ */
+@Schema(description = "사업계획서 섹션 응답")
+public record BizPlanSectionResponse(
+
+        /** 프로젝트 ID */
+        @Schema(description = "프로젝트 ID")
+        String projectId,
+
+        /** 섹션 타입 */
+        @Schema(description = "섹션 타입", example = "executive_summary")
+        String sectionType,
+
+        /** 섹션 제목 */
+        @Schema(description = "섹션 제목", example = "사업개요")
+        String title,
+
+        /** 섹션 내용 */
+        @Schema(description = "섹션 내용")
+        String content,
+
+        /** 글자 수 */
+        @Schema(description = "글자 수", example = "500")
+        Integer wordCount,
+
+        /** 사용된 모델 */
+        @Schema(description = "생성에 사용된 AI 모델", example = "gemini-1.5-pro")
+        String modelUsed,
+
+        /** 생성 소요 시간 (ms) */
+        @Schema(description = "AI 생성 소요 시간 (ms)", example = "3500")
+        Integer generationTimeMs,
+
+        /** 개선 제안 */
+        @Schema(description = "AI의 개선 제안 (Expert 모드)")
+        List<String> suggestions,
+
+        /** 일관성 경고 */
+        @Schema(description = "다른 섹션과의 일관성 경고")
+        List<String> consistencyWarnings,
+
+        /** 수정일시 */
+        @Schema(description = "마지막 수정일시")
+        LocalDateTime updatedAt
+) {
+    /**
+     * 엔티티로부터 생성.
+     */
+    public static BizPlanSectionResponse from(BizPlanSection section) {
+        return new BizPlanSectionResponse(
+                section.getProjectId(),
+                section.getSectionType(),
+                section.getTitle(),
+                section.getContent(),
+                section.getWordCount(),
+                section.getModelUsed(),
+                section.getGenerationTimeMs(),
+                null,
+                null,
+                section.getUpdatedAt()
+        );
+    }
+
+    /**
+     * AI 생성 결과로부터 생성 (제안 및 경고 포함).
+     */
+    public static BizPlanSectionResponse fromAiResult(
+            BizPlanSection section,
+            List<String> suggestions,
+            List<String> consistencyWarnings
+    ) {
+        return new BizPlanSectionResponse(
+                section.getProjectId(),
+                section.getSectionType(),
+                section.getTitle(),
+                section.getContent(),
+                section.getWordCount(),
+                section.getModelUsed(),
+                section.getGenerationTimeMs(),
+                suggestions,
+                consistencyWarnings,
+                section.getUpdatedAt()
+        );
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/BizPlanSectionsListResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/BizPlanSectionsListResponse.java
@@ -1,0 +1,64 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * 사업계획서 섹션 목록 응답 DTO.
+ */
+@Schema(description = "사업계획서 섹션 목록 응답")
+public record BizPlanSectionsListResponse(
+
+        /** 프로젝트 ID */
+        @Schema(description = "프로젝트 ID")
+        String projectId,
+
+        /** 섹션 목록 */
+        @Schema(description = "섹션 목록")
+        List<SectionSummary> sections,
+
+        /** 총 섹션 수 */
+        @Schema(description = "총 섹션 수", example = "10")
+        int totalSections,
+
+        /** 완료된 섹션 수 */
+        @Schema(description = "완료된 섹션 수", example = "3")
+        int completedSections
+) {
+    /**
+     * 섹션 요약 정보.
+     */
+    @Schema(description = "섹션 요약 정보")
+    public record SectionSummary(
+            /** 섹션 타입 */
+            @Schema(description = "섹션 타입", example = "executive_summary")
+            String sectionType,
+
+            /** 섹션 제목 */
+            @Schema(description = "섹션 제목", example = "사업개요")
+            String title,
+
+            /** 글자 수 */
+            @Schema(description = "글자 수", example = "500")
+            Integer wordCount,
+
+            /** 수정일시 */
+            @Schema(description = "마지막 수정일시")
+            java.time.LocalDateTime updatedAt
+    ) {}
+
+    /**
+     * 팩토리 메서드.
+     */
+    public static BizPlanSectionsListResponse of(
+            String projectId,
+            List<SectionSummary> sections
+    ) {
+        // 지원되는 전체 섹션 수 (10개)
+        int totalSections = 10;
+        int completedSections = sections.size();
+        return new BizPlanSectionsListResponse(projectId, sections, totalSections, completedSections);
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/repository/BizPlanSectionRepository.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/repository/BizPlanSectionRepository.java
@@ -1,0 +1,56 @@
+package com.vibe.bizplan.bizplan_be.infrastructure.repository;
+
+import com.vibe.bizplan.bizplan_be.domain.entity.BizPlanSection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 사업계획서 섹션 리포지토리.
+ */
+@Repository
+public interface BizPlanSectionRepository extends JpaRepository<BizPlanSection, String> {
+
+    /**
+     * 프로젝트의 모든 섹션 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 섹션 목록
+     */
+    List<BizPlanSection> findByProjectIdOrderBySectionType(String projectId);
+
+    /**
+     * 프로젝트의 특정 섹션 조회.
+     *
+     * @param projectId   프로젝트 ID
+     * @param sectionType 섹션 타입
+     * @return 섹션 (Optional)
+     */
+    Optional<BizPlanSection> findByProjectIdAndSectionType(String projectId, String sectionType);
+
+    /**
+     * 프로젝트의 섹션 개수 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @return 섹션 개수
+     */
+    int countByProjectId(String projectId);
+
+    /**
+     * 프로젝트의 모든 섹션 삭제.
+     *
+     * @param projectId 프로젝트 ID
+     */
+    void deleteByProjectId(String projectId);
+
+    /**
+     * 프로젝트의 특정 섹션 삭제.
+     *
+     * @param projectId   프로젝트 ID
+     * @param sectionType 섹션 타입
+     */
+    void deleteByProjectIdAndSectionType(String projectId, String sectionType);
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,11 +33,26 @@ spring.flyway.baseline-on-migrate=true
 spring.flyway.locations=classpath:db/migration
 
 # ==========================================
-# API Documentation (SpringDoc)
+# API Documentation (SpringDoc OpenAPI)
 # ==========================================
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
+
+# Swagger UI 설정
 springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.tagsSorter=alpha
+springdoc.swagger-ui.display-request-duration=true
+springdoc.swagger-ui.doc-expansion=none
+springdoc.swagger-ui.filter=true
+springdoc.swagger-ui.show-extensions=true
+springdoc.swagger-ui.show-common-extensions=true
+
+# 기본 produces/consumes 미디어 타입
+springdoc.default-produces-media-type=application/json
+springdoc.default-consumes-media-type=application/json
+
+# 인증이 필요 없는 엔드포인트에서 보안 표시 제거
+springdoc.show-actuator=false
 
 # ==========================================
 # Security Configuration

--- a/src/main/resources/db/migration/V6__create_bizplan_sections_table.sql
+++ b/src/main/resources/db/migration/V6__create_bizplan_sections_table.sql
@@ -1,0 +1,29 @@
+-- =====================================================
+-- V6: BizPlan Sections 테이블 생성
+-- AI 생성 사업계획서 섹션 저장용 테이블
+-- =====================================================
+
+CREATE TABLE bizplan_sections (
+    id VARCHAR(36) PRIMARY KEY,
+    project_id VARCHAR(36) NOT NULL,
+    section_type VARCHAR(50) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    word_count INT DEFAULT 0,
+    model_used VARCHAR(100),
+    generation_time_ms INT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    
+    -- 프로젝트당 섹션 타입은 유일해야 함
+    CONSTRAINT uk_project_section UNIQUE (project_id, section_type),
+    
+    -- 외래 키 제약
+    CONSTRAINT fk_bizplan_sections_project 
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+-- 인덱스
+CREATE INDEX idx_bizplan_sections_project_id ON bizplan_sections(project_id);
+CREATE INDEX idx_bizplan_sections_section_type ON bizplan_sections(section_type);
+

--- a/tasks/functional/BE-AI-001-bizplan-generate.md
+++ b/tasks/functional/BE-AI-001-bizplan-generate.md
@@ -1,0 +1,71 @@
+# [BE-AI-001] 사업계획서 섹션 생성 API 연동
+
+## 📌 우선순위
+🔴 **High**
+
+## 📋 요약
+AI Engine의 `/api/v1/bizplan/generate` API를 연동하여 사업계획서 섹션을 AI로 생성하는 기능 구현
+
+## 🎯 요구사항
+
+### Backend 엔드포인트
+```
+POST /projects/{projectId}/bizplan/sections/{sectionType}/generate
+🔒 Authorization Required
+```
+
+### AI Engine 호출
+```
+POST http://ai-engine:8000/api/v1/bizplan/generate
+```
+
+### Request Body
+```json
+{
+  "mode": "easy",
+  "additionalInstructions": "선택적 추가 지시사항"
+}
+```
+
+### Response (200 OK)
+```json
+{
+  "projectId": "...",
+  "sectionType": "executive_summary",
+  "title": "사업개요",
+  "content": "AI 생성 콘텐츠...",
+  "wordCount": 500,
+  "modelUsed": "gemini-1.5-pro",
+  "generationTimeMs": 3500,
+  "suggestions": ["개선 제안 1"],
+  "consistencyWarnings": []
+}
+```
+
+### 지원 섹션 타입
+- `executive_summary` - 사업개요
+- `problem_definition` - 문제 정의
+- `solution` - 솔루션
+- `market_analysis` - 시장 분석
+- `business_model` - 비즈니스 모델
+- `competitive_analysis` - 경쟁 분석
+- `marketing_strategy` - 마케팅 전략
+- `team` - 팀 소개
+- `financial_plan` - 재무 계획
+- `milestones` - 마일스톤
+
+## ✅ 구현 체크리스트
+- [ ] `BizPlanController` 생성
+- [ ] `BizPlanSectionRequest/Response` DTO 생성
+- [ ] `AiEngineClient.generateSection()` 메서드 구현
+- [ ] `BizPlanService` 생성 (섹션 저장/조회)
+- [ ] `BizPlanSection` 엔티티 생성
+- [ ] V6 마이그레이션: bizplan_sections 테이블
+- [ ] 에러 처리 (타임아웃, AI 장애)
+- [ ] Swagger 문서화
+- [ ] 통합 테스트
+
+## 📎 관련 문서
+- [BE-AI-ENGINE-INTEGRATION.md](./BE-AI-ENGINE-INTEGRATION.md)
+- AI Engine ReDoc: http://localhost:8000/redoc
+

--- a/tasks/functional/BE-AI-002-bizplan-sections-crud.md
+++ b/tasks/functional/BE-AI-002-bizplan-sections-crud.md
@@ -1,0 +1,57 @@
+# [BE-AI-002] 사업계획서 섹션 CRUD API 구현
+
+## 📌 우선순위
+🔴 **High**
+
+## 📋 요약
+생성된 사업계획서 섹션의 조회, 수정, 삭제 기능 구현
+
+## 🎯 요구사항
+
+### 엔드포인트
+
+| 메서드 | URL | 설명 |
+|--------|-----|------|
+| GET | `/projects/{projectId}/bizplan/sections` | 전체 섹션 조회 |
+| GET | `/projects/{projectId}/bizplan/sections/{sectionType}` | 특정 섹션 조회 |
+| PUT | `/projects/{projectId}/bizplan/sections/{sectionType}` | 섹션 수정 |
+| DELETE | `/projects/{projectId}/bizplan/sections/{sectionType}` | 섹션 삭제 |
+
+### Response - 전체 섹션 조회
+```json
+{
+  "projectId": "...",
+  "sections": [
+    {
+      "sectionType": "executive_summary",
+      "title": "사업개요",
+      "content": "...",
+      "wordCount": 500,
+      "updatedAt": "2025-01-01T12:00:00"
+    }
+  ],
+  "totalSections": 3,
+  "completedSections": 2
+}
+```
+
+### Request - 섹션 수정
+```json
+{
+  "title": "수정된 제목",
+  "content": "수정된 내용..."
+}
+```
+
+## ✅ 구현 체크리스트
+- [ ] `BizPlanController`에 CRUD 엔드포인트 추가
+- [ ] `BizPlanSectionRepository` 생성
+- [ ] `BizPlanService` CRUD 메서드 구현
+- [ ] 소유권 검증 로직
+- [ ] 버전 관리 (수정 이력)
+- [ ] Swagger 문서화
+- [ ] 단위 테스트
+
+## 📎 관련 문서
+- [BE-AI-ENGINE-INTEGRATION.md](./BE-AI-ENGINE-INTEGRATION.md)
+

--- a/tasks/functional/BE-AI-003-pmf-ai-diagnose.md
+++ b/tasks/functional/BE-AI-003-pmf-ai-diagnose.md
@@ -1,0 +1,80 @@
+# [BE-AI-003] PMF AI 진단 API 연동
+
+## 📌 우선순위
+🟠 **Medium**
+
+## 📋 요약
+AI Engine의 `/api/v1/pmf/diagnose` API를 연동하여 AI 기반 PMF 진단 기능 구현
+
+## 🎯 요구사항
+
+### Backend 엔드포인트
+```
+POST /projects/{projectId}/pmf/ai-diagnose
+🔒 Authorization Required
+```
+
+### AI Engine 호출
+```
+POST http://ai-engine:8000/api/v1/pmf/diagnose
+```
+
+### Request Body
+```json
+{
+  "includeFinancialData": true
+}
+```
+
+### Response (200 OK)
+```json
+{
+  "projectId": "...",
+  "overallScore": 75,
+  "scoreGrade": "good",
+  "categoryScores": {
+    "market_fit": 80,
+    "problem_solution": 70,
+    "revenue_model": 75
+  },
+  "risks": [
+    {
+      "category": "market",
+      "title": "시장 규모 불확실",
+      "description": "...",
+      "level": "medium",
+      "recommendation": "...",
+      "relatedSections": ["market_analysis"]
+    }
+  ],
+  "strengths": ["강점 1", "강점 2"],
+  "summary": "종합 분석 요약...",
+  "priorityActions": ["우선 조치 1", "우선 조치 2"],
+  "modelUsed": "gemini-1.5-pro",
+  "analysisTimeMs": 3500
+}
+```
+
+### PMF 점수 등급
+| Grade | 점수 범위 | 설명 |
+|-------|----------|------|
+| `excellent` | 80-100 | 뛰어남 |
+| `good` | 60-79 | 좋음 |
+| `fair` | 40-59 | 보통 |
+| `poor` | 20-39 | 미흡 |
+| `critical` | 0-19 | 심각 |
+
+## ✅ 구현 체크리스트
+- [ ] `PmfController`에 AI 진단 엔드포인트 추가
+- [ ] `AiPmfDiagnosisRequest/Response` DTO 생성
+- [ ] `AiEngineClient.diagnosePmf()` 메서드 구현
+- [ ] `PmfService` AI 진단 로직 추가
+- [ ] AI 결과 → PMF 리포트 변환/저장
+- [ ] 에러 처리 (타임아웃, AI 장애)
+- [ ] Swagger 문서화
+- [ ] 통합 테스트
+
+## 📎 관련 문서
+- [BE-AI-ENGINE-INTEGRATION.md](./BE-AI-ENGINE-INTEGRATION.md)
+- AI Engine ReDoc: http://localhost:8000/redoc
+

--- a/tasks/functional/BE-AI-004-auxiliary-apis.md
+++ b/tasks/functional/BE-AI-004-auxiliary-apis.md
@@ -1,0 +1,80 @@
+# [BE-AI-004] AI Engine 보조 API 연동
+
+## 📌 우선순위
+🟡 **Low**
+
+## 📋 요약
+AI Engine의 보조 API (섹션 목록, PMF 평가 기준) 연동
+
+## 🎯 요구사항
+
+### 1. 섹션 타입 목록 조회
+
+```
+GET /bizplan/section-types
+```
+
+#### AI Engine 호출
+```
+GET http://ai-engine:8000/api/v1/bizplan/sections
+```
+
+#### Response
+```json
+{
+  "sectionTypes": [
+    {
+      "type": "executive_summary",
+      "name": "사업개요",
+      "description": "사업의 핵심 내용을 요약합니다."
+    },
+    {
+      "type": "problem_definition",
+      "name": "문제 정의",
+      "description": "해결하고자 하는 문제를 정의합니다."
+    }
+  ]
+}
+```
+
+### 2. PMF 평가 기준 조회
+
+```
+GET /pmf/criteria
+```
+
+#### AI Engine 호출
+```
+GET http://ai-engine:8000/api/v1/pmf/criteria
+```
+
+#### Response
+```json
+{
+  "criteria": [
+    {
+      "category": "market_fit",
+      "name": "시장 적합성",
+      "weight": 0.3,
+      "description": "목표 시장에 대한 적합성 평가"
+    },
+    {
+      "category": "problem_solution",
+      "name": "문제-솔루션 적합성",
+      "weight": 0.25,
+      "description": "문제 해결 능력 평가"
+    }
+  ]
+}
+```
+
+## ✅ 구현 체크리스트
+- [ ] `BizPlanController`에 섹션 타입 목록 엔드포인트 추가
+- [ ] `PmfController`에 평가 기준 엔드포인트 추가
+- [ ] `AiEngineClient` 메서드 추가
+- [ ] 응답 캐싱 (정적 데이터)
+- [ ] Swagger 문서화
+
+## 📎 관련 문서
+- [BE-AI-ENGINE-INTEGRATION.md](./BE-AI-ENGINE-INTEGRATION.md)
+

--- a/tasks/functional/BE-AI-ENGINE-INTEGRATION.md
+++ b/tasks/functional/BE-AI-ENGINE-INTEGRATION.md
@@ -1,0 +1,384 @@
+# Backend-AI Engine 연동 계획서
+
+> 📅 작성일: 2025-12-20  
+> 📌 목적: Backend Core(Java/Spring Boot)와 AI Engine(Python/FastAPI) 간 API 연동
+
+---
+
+## 1. AI Engine API 현황
+
+### 기본 정보
+- **URL**: `http://localhost:8000` (개발) / `${AI_ENGINE_URL}` (운영)
+- **문서**: http://localhost:8000/redoc, http://localhost:8000/docs
+- **버전**: 0.1.0
+
+### API 목록
+
+| # | 엔드포인트 | 메서드 | 설명 | 상태 |
+|---|-----------|--------|------|------|
+| 1 | `/health` | GET | 헬스 체크 | ✅ 연동됨 |
+| 2 | `/ready` | GET | 준비 상태 체크 (LLM 연결) | ✅ 연동됨 |
+| 3 | `/api/v1/bizplan/generate` | POST | 사업계획서 섹션 생성 | 🔲 미연동 |
+| 4 | `/api/v1/bizplan/sections` | GET | 지원 섹션 목록 조회 | 🔲 미연동 |
+| 5 | `/api/v1/pmf/diagnose` | POST | PMF 진단 | 🔲 미연동 |
+| 6 | `/api/v1/pmf/criteria` | GET | PMF 평가 기준 조회 | 🔲 미연동 |
+
+---
+
+## 2. 연동 필요 API 상세
+
+### 2.1 사업계획서 섹션 생성 API
+
+#### AI Engine 스펙
+```
+POST /api/v1/bizplan/generate
+```
+
+#### Request Body
+```json
+{
+  "project_id": "string",
+  "template_code": "string",
+  "section_type": "executive_summary | problem_definition | solution | market_analysis | business_model | competitive_analysis | marketing_strategy | team | financial_plan | milestones",
+  "mode": "easy | expert",
+  "context": { },
+  "previous_sections": { "section_type": "content" },
+  "additional_instructions": "string"
+}
+```
+
+#### Response
+```json
+{
+  "project_id": "string",
+  "section": {
+    "section_type": "string",
+    "title": "string",
+    "content": "string",
+    "word_count": 0,
+    "model_used": "string",
+    "generation_time_ms": 0,
+    "token_usage": { "input": 0, "output": 0 }
+  },
+  "suggestions": ["개선 제안 1", "개선 제안 2"],
+  "consistency_warnings": ["일관성 경고 1"]
+}
+```
+
+#### Backend 연동 계획
+| 항목 | 내용 |
+|------|------|
+| BE 엔드포인트 | `POST /projects/{projectId}/bizplan/sections/{sectionType}` |
+| Controller | `BizPlanController` (신규) |
+| Service | `BizPlanOrchestrationService` 활용/확장 |
+| Client | `AiEngineClient` 확장 |
+
+---
+
+### 2.2 지원 섹션 목록 API
+
+#### AI Engine 스펙
+```
+GET /api/v1/bizplan/sections
+```
+
+#### Response
+```json
+{
+  "sections": [
+    "executive_summary",
+    "problem_definition",
+    "solution",
+    "market_analysis",
+    "business_model",
+    "competitive_analysis",
+    "marketing_strategy",
+    "team",
+    "financial_plan",
+    "milestones"
+  ]
+}
+```
+
+#### Backend 연동 계획
+| 항목 | 내용 |
+|------|------|
+| BE 엔드포인트 | `GET /bizplan/sections` |
+| Controller | `BizPlanController` (신규) |
+| 캐싱 | 가능 (정적 데이터) |
+
+---
+
+### 2.3 PMF AI 진단 API
+
+#### AI Engine 스펙
+```
+POST /api/v1/pmf/diagnose
+```
+
+#### Request Body
+```json
+{
+  "project_id": "string",
+  "context": { },
+  "bizplan_sections": { "section_type": "content" },
+  "financial_data": { }
+}
+```
+
+#### Response
+```json
+{
+  "project_id": "string",
+  "overall_score": 75,
+  "score_grade": "excellent | good | fair | poor | critical",
+  "category_scores": {
+    "market_fit": 80,
+    "problem_solution": 70,
+    "revenue_model": 75
+  },
+  "risks": [
+    {
+      "category": "market",
+      "title": "시장 규모 불확실",
+      "description": "...",
+      "level": "low | medium | high | critical",
+      "recommendation": "...",
+      "related_sections": ["market_analysis"]
+    }
+  ],
+  "strengths": ["강점 1", "강점 2"],
+  "summary": "종합 분석 요약",
+  "priority_actions": ["우선 조치 1", "우선 조치 2", "우선 조치 3"],
+  "model_used": "gemini-1.5-pro",
+  "analysis_time_ms": 3500
+}
+```
+
+#### Backend 연동 계획
+| 항목 | 내용 |
+|------|------|
+| BE 엔드포인트 | `POST /projects/{projectId}/pmf/ai-diagnose` |
+| Controller | `PmfController` 확장 |
+| Service | `PmfService` 확장 |
+| Client | `AiEngineClient` 확장 |
+| 저장 | PMF 리포트로 저장 |
+
+---
+
+### 2.4 PMF 평가 기준 조회 API
+
+#### AI Engine 스펙
+```
+GET /api/v1/pmf/criteria
+```
+
+#### Response
+```json
+{
+  "criteria": [
+    {
+      "category": "market_fit",
+      "name": "시장 적합성",
+      "weight": 0.3,
+      "description": "..."
+    }
+  ]
+}
+```
+
+#### Backend 연동 계획
+| 항목 | 내용 |
+|------|------|
+| BE 엔드포인트 | `GET /pmf/criteria` |
+| Controller | `PmfController` 확장 |
+| 캐싱 | 가능 (정적 데이터) |
+
+---
+
+## 3. 구현 작업 목록
+
+### Phase 1: 사업계획서 생성 (🔴 High Priority)
+
+| # | 작업 | 예상 공수 | 담당 |
+|---|------|----------|------|
+| 1 | `BizPlanController` 생성 | 0.5일 | BE |
+| 2 | `AiEngineClient.generateSection()` 구현 | 0.5일 | BE |
+| 3 | `BizPlanSectionRequest/Response` DTO 생성 | 0.25일 | BE |
+| 4 | 생성된 섹션 저장 로직 | 0.5일 | BE |
+| 5 | 섹션 조회/수정 API | 0.5일 | BE |
+| 6 | 통합 테스트 | 0.5일 | BE |
+
+### Phase 2: PMF AI 진단 (🟠 Medium Priority)
+
+| # | 작업 | 예상 공수 | 담당 |
+|---|------|----------|------|
+| 1 | `PmfController` AI 진단 엔드포인트 추가 | 0.25일 | BE |
+| 2 | `AiEngineClient.diagnosePmf()` 구현 | 0.5일 | BE |
+| 3 | AI 진단 결과 → PMF 리포트 변환 | 0.5일 | BE |
+| 4 | 통합 테스트 | 0.5일 | BE |
+
+### Phase 3: 보조 API (🟡 Low Priority)
+
+| # | 작업 | 예상 공수 | 담당 |
+|---|------|----------|------|
+| 1 | 섹션 목록 조회 API | 0.25일 | BE |
+| 2 | PMF 평가 기준 조회 API | 0.25일 | BE |
+
+---
+
+## 4. 기술 구현 상세
+
+### 4.1 AiEngineClient 확장
+
+```java
+// 현재 구현된 AiEngineClient 위치
+// src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/AiEngineClient.java
+
+// 추가할 메서드
+public interface AiEngineClient {
+    
+    // 사업계획서 섹션 생성
+    BizPlanSectionResponse generateSection(BizPlanSectionRequest request);
+    
+    // 지원 섹션 목록
+    List<String> getSupportedSections();
+    
+    // PMF AI 진단
+    AiPmfDiagnosisResponse diagnosePmf(AiPmfDiagnosisRequest request);
+    
+    // PMF 평가 기준
+    List<PmfCriteriaResponse> getPmfCriteria();
+}
+```
+
+### 4.2 DTO 매핑
+
+```
+AI Engine                    Backend
+─────────────────────────    ─────────────────────────
+BizPlanGenerateRequest   →   BizPlanSectionRequest (신규)
+BizPlanGenerateResponse  ←   BizPlanSectionResponse (신규)
+PMFDiagnosticRequest     →   AiPmfDiagnosisRequest (신규)
+PMFDiagnosticResponse    ←   AiPmfDiagnosisResponse (신규)
+```
+
+### 4.3 에러 처리
+
+| AI Engine 상태 | Backend 처리 |
+|---------------|-------------|
+| 200 OK | 정상 응답 |
+| 422 Validation Error | `400 Bad Request` 변환 |
+| 500 Internal Error | `503 Service Unavailable` + 재시도 |
+| Timeout | `504 Gateway Timeout` + 폴백 |
+
+### 4.4 타임아웃 설정
+
+```properties
+# application.properties
+ai.engine.url=${AI_ENGINE_URL:http://localhost:8000}
+ai.engine.timeout=60  # 초 (LLM 생성 시간 고려)
+ai.engine.connect-timeout=5
+ai.engine.read-timeout=60
+```
+
+---
+
+## 5. 데이터 모델 추가
+
+### 5.1 BizPlanSection 엔티티 (신규)
+
+```sql
+-- V6__create_bizplan_section_table.sql
+CREATE TABLE bizplan_sections (
+    id VARCHAR(36) PRIMARY KEY,
+    project_id VARCHAR(36) NOT NULL,
+    section_type VARCHAR(50) NOT NULL,
+    title VARCHAR(255),
+    content TEXT,
+    word_count INT,
+    model_used VARCHAR(50),
+    generation_time_ms INT,
+    version INT DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    
+    CONSTRAINT fk_bizplan_section_project 
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    UNIQUE KEY uk_project_section (project_id, section_type)
+);
+```
+
+---
+
+## 6. API 설계 (Backend)
+
+### 6.1 사업계획서 API
+
+| 메서드 | 엔드포인트 | 설명 |
+|--------|-----------|------|
+| POST | `/projects/{projectId}/bizplan/sections/{sectionType}/generate` | 섹션 생성 (AI) |
+| GET | `/projects/{projectId}/bizplan/sections` | 전체 섹션 조회 |
+| GET | `/projects/{projectId}/bizplan/sections/{sectionType}` | 특정 섹션 조회 |
+| PUT | `/projects/{projectId}/bizplan/sections/{sectionType}` | 섹션 수정 |
+| DELETE | `/projects/{projectId}/bizplan/sections/{sectionType}` | 섹션 삭제 |
+| GET | `/bizplan/section-types` | 지원 섹션 타입 목록 |
+
+### 6.2 PMF AI 진단 API
+
+| 메서드 | 엔드포인트 | 설명 |
+|--------|-----------|------|
+| POST | `/projects/{projectId}/pmf/ai-diagnose` | AI 기반 PMF 진단 |
+| GET | `/pmf/criteria` | PMF 평가 기준 조회 |
+
+---
+
+## 7. 우선순위 및 일정
+
+| 단계 | 내용 | 예상 기간 | 우선순위 |
+|------|------|----------|----------|
+| **Phase 1** | 사업계획서 섹션 생성 API | 2.5일 | 🔴 High |
+| **Phase 2** | PMF AI 진단 연동 | 1.5일 | 🟠 Medium |
+| **Phase 3** | 보조 API (목록/기준 조회) | 0.5일 | 🟡 Low |
+| **총계** | | **4.5일** | |
+
+---
+
+## 8. 테스트 계획
+
+### 8.1 단위 테스트
+- `AiEngineClientTest`: Mock 서버로 API 호출 테스트
+- `BizPlanServiceTest`: 섹션 생성/저장 로직 테스트
+
+### 8.2 통합 테스트
+- AI Engine 실제 연동 테스트 (테스트 환경)
+- 타임아웃 및 에러 처리 테스트
+
+### 8.3 성능 테스트
+- 섹션 생성 응답 시간 (목표: p95 < 10초)
+- 동시 요청 처리 테스트
+
+---
+
+## 9. 리스크 및 대응
+
+| 리스크 | 영향 | 대응 방안 |
+|--------|------|----------|
+| AI Engine 응답 지연 | 사용자 경험 저하 | 비동기 처리 + 폴링 |
+| LLM 토큰 비용 | 운영 비용 증가 | 캐싱 + 요청 최적화 |
+| AI Engine 장애 | 핵심 기능 불가 | 폴백 메시지 + 알림 |
+
+---
+
+## 10. 참고 문서
+
+- AI Engine API 문서: http://localhost:8000/redoc
+- Backend API 문서: http://localhost:8080/swagger-ui.html
+- [기존 AiEngineClient 코드](../src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/AiEngineClient.java)
+
+---
+
+## 문의
+
+추가 질문이나 스펙 변경이 필요하면 연락 부탁드립니다.
+

--- a/tasks/functional/BE-API-001-project-update.md
+++ b/tasks/functional/BE-API-001-project-update.md
@@ -1,0 +1,58 @@
+# [BE-API-001] 프로젝트 수정 API 구현
+
+## 📌 우선순위
+🔴 **High**
+
+## 📋 요약
+프로젝트 제목 및 메타데이터를 수정할 수 있는 API 엔드포인트 구현
+
+## 🎯 요구사항
+
+### 엔드포인트
+```
+PATCH /projects/{projectId}
+🔒 Authorization Required
+```
+
+### Request Body
+```json
+{
+  "title": "수정된 프로젝트명",
+  "status": "IN_PROGRESS"
+}
+```
+
+### Response (200 OK)
+```json
+{
+  "projectId": "project-uuid",
+  "templateCode": "pre-startup",
+  "title": "수정된 프로젝트명",
+  "status": "IN_PROGRESS",
+  "updatedAt": "2025-01-01T12:00:00"
+}
+```
+
+### 에러 처리
+| Status | Description |
+|--------|-------------|
+| 400 | 유효하지 않은 요청 데이터 |
+| 401 | 인증 필요 |
+| 403 | 권한 없음 (본인 프로젝트가 아님) |
+| 404 | 프로젝트 없음 |
+
+## ✅ 구현 체크리스트
+- [ ] ProjectController에 PATCH 엔드포인트 추가
+- [ ] ProjectUpdateRequest DTO 생성
+- [ ] ProjectService에 updateProject 메서드 구현
+- [ ] 소유권 검증 로직 추가
+- [ ] 단위 테스트 작성
+- [ ] Swagger 문서화
+
+## 🔗 사용처
+- 프로젝트 설정 페이지
+- 프로젝트 이름 변경 기능
+
+## 📎 관련 문서
+- [BE-API-REQUEST.md](./BE-API-REQUEST.md)
+

--- a/tasks/functional/BE-API-002-project-delete.md
+++ b/tasks/functional/BE-API-002-project-delete.md
@@ -1,0 +1,42 @@
+# [BE-API-002] 프로젝트 삭제 API 구현
+
+## 📌 우선순위
+🔴 **High**
+
+## 📋 요약
+사용자가 자신의 프로젝트를 삭제할 수 있는 API 엔드포인트 구현
+
+## 🎯 요구사항
+
+### 엔드포인트
+```
+DELETE /projects/{projectId}
+🔒 Authorization Required
+```
+
+### Response (204 No Content)
+성공 시 본문 없음
+
+### 에러 처리
+| Status | Description |
+|--------|-------------|
+| 401 | 인증 필요 |
+| 403 | 권한 없음 (본인 프로젝트가 아님) |
+| 404 | 프로젝트 없음 |
+
+## ✅ 구현 체크리스트
+- [ ] ProjectController에 DELETE 엔드포인트 추가
+- [ ] ProjectService에 deleteProject 메서드 구현
+- [ ] 소유권 검증 로직 추가
+- [ ] 관련 데이터 삭제 처리 (Wizard Answers, Documents 등)
+- [ ] Soft Delete vs Hard Delete 결정
+- [ ] 단위 테스트 작성
+- [ ] Swagger 문서화
+
+## 🔗 사용처
+- 프로젝트 목록 페이지 (삭제 버튼)
+- 프로젝트 설정 페이지
+
+## 📎 관련 문서
+- [BE-API-REQUEST.md](./BE-API-REQUEST.md)
+

--- a/tasks/functional/BE-API-003-wizard-steps.md
+++ b/tasks/functional/BE-API-003-wizard-steps.md
@@ -1,0 +1,84 @@
+# [BE-API-003] 위저드 단계 정의 조회 API 구현
+
+## 📌 우선순위
+🟠 **Medium**
+
+## 📋 요약
+템플릿별 위저드 단계 및 질문 정의를 조회하는 API 엔드포인트 구현
+
+## 🎯 배경
+현재 프론트엔드에서 `mockData.ts`의 하드코딩된 `wizardSteps`를 사용 중.
+템플릿마다 다른 질문 세트가 필요할 수 있음.
+
+## 🎯 요구사항
+
+### 엔드포인트 (Option 1: 프로젝트 기반)
+```
+GET /projects/{projectId}/wizard/steps
+🔒 Authorization Required
+```
+
+### 엔드포인트 (Option 2: 템플릿 기반)
+```
+GET /templates/{templateCode}/wizard/steps
+```
+
+### Response (200 OK)
+```json
+{
+  "templateCode": "pre-startup",
+  "totalSteps": 5,
+  "steps": [
+    {
+      "id": 1,
+      "title": "사업 아이디어",
+      "description": "사업 아이디어를 설명해주세요",
+      "questions": [
+        {
+          "id": "business-name",
+          "type": "text",
+          "label": "사업명",
+          "placeholder": "사업명을 입력하세요",
+          "required": true,
+          "maxLength": 100
+        },
+        {
+          "id": "business-description",
+          "type": "textarea",
+          "label": "사업 설명",
+          "placeholder": "사업 아이디어를 설명해주세요",
+          "required": true,
+          "maxLength": 1000
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Question Type 정의
+| Type | Description |
+|------|-------------|
+| `text` | 한 줄 텍스트 입력 |
+| `textarea` | 여러 줄 텍스트 입력 |
+| `number` | 숫자 입력 |
+| `select` | 단일 선택 (드롭다운) |
+| `multiselect` | 복수 선택 |
+| `date` | 날짜 선택 |
+| `radio` | 라디오 버튼 |
+
+## ✅ 구현 체크리스트
+- [ ] WizardStepDefinition 엔티티 또는 설정 파일 구조 설계
+- [ ] WizardController 또는 TemplateController 생성
+- [ ] 단계/질문 정의 데이터 소스 결정 (DB vs JSON 파일)
+- [ ] Response DTO 생성
+- [ ] 단위 테스트 작성
+- [ ] Swagger 문서화
+
+## 🔗 사용처
+- WizardStep 컴포넌트
+- QuestionForm 컴포넌트
+
+## 📎 관련 문서
+- [BE-API-REQUEST.md](./BE-API-REQUEST.md)
+

--- a/tasks/functional/BE-API-004-financials-get.md
+++ b/tasks/functional/BE-API-004-financials-get.md
@@ -1,0 +1,68 @@
+# [BE-API-004] 재무 데이터 조회 API 구현
+
+## 📌 우선순위
+🟠 **Medium**
+
+## 📋 요약
+저장된 재무 시뮬레이션 데이터를 조회하는 API 엔드포인트 구현
+
+## 🎯 배경
+현재 `/financials/generate`만 있고, 이전에 생성한 재무 데이터를 조회하는 API가 없음.
+재접속 시 마지막 시뮬레이션 결과를 표시해야 함.
+
+## 🎯 요구사항
+
+### 엔드포인트
+```
+GET /projects/{projectId}/financials
+🔒 Authorization Required
+```
+
+### Response (200 OK)
+```json
+{
+  "projectId": "project-uuid",
+  "assumptions": {
+    "initialCapital": 50000000,
+    "averageRevenuePerUser": 30000,
+    "monthlyMarketingBudget": 5000000,
+    "customerAcquisitionCost": 10000,
+    "monthlyChurnRate": 0.05,
+    "monthlyFixedCosts": 10000000
+  },
+  "monthlyPL": [...],
+  "yearlySummary": [...],
+  "unitEconomics": {
+    "ltv": 600000,
+    "cac": 10000,
+    "ltvCacRatio": 60,
+    "paybackPeriodMonths": 3
+  },
+  "createdAt": "2025-01-01T12:00:00",
+  "updatedAt": "2025-01-01T12:00:00"
+}
+```
+
+### Response (404 Not Found)
+재무 데이터가 없는 경우
+```json
+{
+  "message": "재무 데이터가 없습니다."
+}
+```
+
+## ✅ 구현 체크리스트
+- [ ] FinancialsController에 GET 엔드포인트 추가
+- [ ] FinancialData 엔티티 설계 (또는 기존 구조 활용)
+- [ ] FinancialsService에 getFinancials 메서드 구현
+- [ ] Response DTO 생성
+- [ ] 단위 테스트 작성
+- [ ] Swagger 문서화
+
+## 🔗 사용처
+- FinancialSimulation 컴포넌트 (초기 로드)
+- 사업계획서 재무 섹션
+
+## 📎 관련 문서
+- [BE-API-REQUEST.md](./BE-API-REQUEST.md)
+

--- a/tasks/functional/BE-API-005-financials-save.md
+++ b/tasks/functional/BE-API-005-financials-save.md
@@ -1,0 +1,66 @@
+# [BE-API-005] 재무 데이터 저장 API 구현
+
+## 📌 우선순위
+🟠 **Medium**
+
+## 📋 요약
+재무 가정값만 저장 (시뮬레이션 재실행 없이)하는 API 엔드포인트 구현
+
+## 🎯 배경
+현재 `/financials/generate`는 항상 시뮬레이션을 다시 실행함.
+가정값만 저장하고 싶을 때 사용.
+
+## 🎯 요구사항
+
+### 엔드포인트
+```
+PUT /projects/{projectId}/financials/assumptions
+🔒 Authorization Required
+```
+
+### Request Body
+```json
+{
+  "initialCapital": 50000000,
+  "averageRevenuePerUser": 30000,
+  "monthlyMarketingBudget": 5000000,
+  "customerAcquisitionCost": 10000,
+  "monthlyChurnRate": 0.05,
+  "monthlyFixedCosts": 10000000,
+  "variableCostRate": 0.3,
+  "initialCustomers": 100,
+  "projectionMonths": 36
+}
+```
+
+### Response (200 OK)
+```json
+{
+  "message": "저장되었습니다.",
+  "updatedAt": "2025-01-01T12:00:00"
+}
+```
+
+### 에러 처리
+| Status | Description |
+|--------|-------------|
+| 400 | 유효하지 않은 가정값 |
+| 401 | 인증 필요 |
+| 403 | 권한 없음 |
+| 404 | 프로젝트 없음 |
+
+## ✅ 구현 체크리스트
+- [ ] FinancialsController에 PUT 엔드포인트 추가
+- [ ] FinancialAssumptionsRequest DTO 생성
+- [ ] FinancialsService에 saveAssumptions 메서드 구현
+- [ ] 유효성 검증 로직 추가
+- [ ] 단위 테스트 작성
+- [ ] Swagger 문서화
+
+## 🔗 사용처
+- 자동 저장 기능 (Auto-save)
+- 임시 저장 버튼
+
+## 📎 관련 문서
+- [BE-API-REQUEST.md](./BE-API-REQUEST.md)
+

--- a/tasks/functional/BE-API-006-pmf-questions.md
+++ b/tasks/functional/BE-API-006-pmf-questions.md
@@ -1,0 +1,66 @@
+# [BE-API-006] PMF 설문 질문 조회 API 구현
+
+## 📌 우선순위
+🟡 **Low**
+
+## 📋 요약
+PMF(Product-Market Fit) 진단용 설문 질문 목록을 조회하는 API 엔드포인트 구현
+
+## 🎯 요구사항
+
+### 엔드포인트 (Option 1: 기본)
+```
+GET /pmf/questions
+```
+
+### 엔드포인트 (Option 2: 템플릿별)
+```
+GET /templates/{templateCode}/pmf/questions
+```
+
+### Response (200 OK)
+```json
+{
+  "questions": [
+    {
+      "id": "pmf-1",
+      "question": "만약 이 제품을 더 이상 사용할 수 없게 된다면 어떻게 느끼시겠습니까?",
+      "type": "radio",
+      "required": true,
+      "options": [
+        { "value": 1, "label": "매우 실망할 것이다" },
+        { "value": 2, "label": "다소 실망할 것이다" },
+        { "value": 3, "label": "실망하지 않을 것이다" },
+        { "value": 4, "label": "해당 없음" }
+      ]
+    },
+    {
+      "id": "pmf-2",
+      "question": "이 제품의 주요 혜택은 무엇입니까?",
+      "type": "multiselect",
+      "required": true,
+      "options": [
+        { "value": 1, "label": "시간 절약" },
+        { "value": 2, "label": "비용 절감" },
+        { "value": 3, "label": "품질 향상" },
+        { "value": 4, "label": "기타" }
+      ]
+    }
+  ]
+}
+```
+
+## ✅ 구현 체크리스트
+- [ ] PmfController 생성
+- [ ] PMF 질문 데이터 소스 설계 (DB vs JSON 설정 파일)
+- [ ] PmfQuestionResponse DTO 생성
+- [ ] 단위 테스트 작성
+- [ ] Swagger 문서화
+
+## 🔗 사용처
+- PMFSurvey 컴포넌트
+- 위저드 5단계
+
+## 📎 관련 문서
+- [BE-API-REQUEST.md](./BE-API-REQUEST.md)
+

--- a/tasks/functional/BE-API-007-pmf-submit.md
+++ b/tasks/functional/BE-API-007-pmf-submit.md
@@ -1,0 +1,77 @@
+# [BE-API-007] PMF 설문 결과 제출 API 구현
+
+## 📌 우선순위
+🟡 **Low**
+
+## 📋 요약
+PMF 설문 답변을 제출하고 분석 결과를 생성하는 API 엔드포인트 구현
+
+## 🎯 요구사항
+
+### 엔드포인트
+```
+POST /projects/{projectId}/pmf/submit
+🔒 Authorization Required
+```
+
+### Request Body
+```json
+{
+  "answers": [
+    { "questionId": "pmf-1", "value": 1 },
+    { "questionId": "pmf-2", "value": [1, 2] },
+    { "questionId": "pmf-3", "value": 1 }
+  ]
+}
+```
+
+### Response (200 OK)
+```json
+{
+  "projectId": "project-uuid",
+  "score": 42,
+  "level": "excellent",
+  "risks": [
+    {
+      "id": "risk-1",
+      "title": "시장 검증 필요",
+      "description": "더 많은 고객 피드백이 필요합니다.",
+      "severity": "medium"
+    }
+  ],
+  "recommendations": [
+    {
+      "id": "rec-1",
+      "title": "고객 인터뷰 진행",
+      "description": "핵심 고객층과 심층 인터뷰를 진행하세요.",
+      "priority": "high"
+    }
+  ],
+  "createdAt": "2025-01-01T12:00:00"
+}
+```
+
+### PMF Level 정의
+| Level | Score 범위 | 설명 |
+|-------|-----------|------|
+| `excellent` | 40% 이상 | PMF 달성 |
+| `high` | 30-39% | 거의 달성 |
+| `medium` | 20-29% | 개선 필요 |
+| `low` | 20% 미만 | PMF 미달성 |
+
+## ✅ 구현 체크리스트
+- [ ] PmfController에 POST 엔드포인트 추가
+- [ ] PmfSubmitRequest DTO 생성
+- [ ] PmfReport 엔티티 설계
+- [ ] PMF 점수 계산 로직 구현
+- [ ] 리스크/추천사항 생성 로직 구현
+- [ ] PmfService 구현
+- [ ] 단위 테스트 작성
+- [ ] Swagger 문서화
+
+## 🔗 사용처
+- PMFSurvey 컴포넌트 (결과 제출)
+
+## 📎 관련 문서
+- [BE-API-REQUEST.md](./BE-API-REQUEST.md)
+

--- a/tasks/functional/BE-API-008-pmf-report.md
+++ b/tasks/functional/BE-API-008-pmf-report.md
@@ -1,0 +1,68 @@
+# [BE-API-008] PMF 리포트 조회 API 구현
+
+## 📌 우선순위
+🟡 **Low**
+
+## 📋 요약
+저장된 PMF 분석 결과를 조회하는 API 엔드포인트 구현
+
+## 🎯 요구사항
+
+### 엔드포인트
+```
+GET /projects/{projectId}/pmf/report
+🔒 Authorization Required
+```
+
+### Response (200 OK)
+```json
+{
+  "projectId": "project-uuid",
+  "score": 42,
+  "level": "excellent",
+  "risks": [
+    {
+      "id": "risk-1",
+      "title": "시장 검증 필요",
+      "description": "더 많은 고객 피드백이 필요합니다.",
+      "severity": "medium"
+    }
+  ],
+  "recommendations": [
+    {
+      "id": "rec-1",
+      "title": "고객 인터뷰 진행",
+      "description": "핵심 고객층과 심층 인터뷰를 진행하세요.",
+      "priority": "high"
+    }
+  ],
+  "answers": [
+    { "questionId": "pmf-1", "value": 1 },
+    { "questionId": "pmf-2", "value": [1, 2] }
+  ],
+  "createdAt": "2025-01-01T12:00:00"
+}
+```
+
+### Response (404 Not Found)
+PMF 리포트가 없는 경우
+```json
+{
+  "message": "PMF 리포트가 없습니다."
+}
+```
+
+## ✅ 구현 체크리스트
+- [ ] PmfController에 GET 엔드포인트 추가
+- [ ] PmfReportResponse DTO 생성
+- [ ] PmfService에 getReport 메서드 구현
+- [ ] 단위 테스트 작성
+- [ ] Swagger 문서화
+
+## 🔗 사용처
+- PMFSurvey 컴포넌트 (이전 결과 로드)
+- 사업계획서 PMF 섹션
+
+## 📎 관련 문서
+- [BE-API-REQUEST.md](./BE-API-REQUEST.md)
+

--- a/tasks/functional/BE-API-REQUEST.md
+++ b/tasks/functional/BE-API-REQUEST.md
@@ -1,0 +1,473 @@
+# 백엔드 API 추가 개발 요청서
+
+> 📅 작성일: 2025-12-20  
+> 👤 요청자: Frontend Team  
+> 📌 우선순위: 🔴 High / 🟠 Medium / 🟡 Low
+
+---
+
+## 요약
+
+프론트엔드에서 필요하지만 현재 백엔드 API에 없는 엔드포인트 목록입니다.
+
+| # | API | 우선순위 | 카테고리 |
+|---|-----|---------|---------|
+| 1 | 프로젝트 수정 | 🔴 High | Projects |
+| 2 | 프로젝트 삭제 | 🔴 High | Projects |
+| 3 | 위저드 단계 정의 조회 | 🟠 Medium | Wizard |
+| 4 | 재무 데이터 조회 | 🟠 Medium | Financials |
+| 5 | 재무 데이터 저장 | 🟠 Medium | Financials |
+| 6 | PMF 설문 질문 조회 | 🟡 Low | PMF |
+| 7 | PMF 설문 결과 제출 | 🟡 Low | PMF |
+| 8 | PMF 리포트 조회 | 🟡 Low | PMF |
+
+---
+
+## 1. 프로젝트 수정 API 🔴
+
+### 요청 사항
+프로젝트 제목 및 메타데이터 수정 기능
+
+### 엔드포인트
+```
+PATCH /projects/{projectId}
+🔒 Authorization Required
+```
+
+### Request Body
+```json
+{
+  "title": "수정된 프로젝트명",
+  "status": "IN_PROGRESS"
+}
+```
+
+### Response (200)
+```json
+{
+  "projectId": "project-uuid",
+  "templateCode": "pre-startup",
+  "title": "수정된 프로젝트명",
+  "status": "IN_PROGRESS",
+  "updatedAt": "2025-01-01T12:00:00"
+}
+```
+
+### 사용처
+- 프로젝트 설정 페이지
+- 프로젝트 이름 변경 기능
+
+---
+
+## 2. 프로젝트 삭제 API 🔴
+
+### 요청 사항
+사용자가 자신의 프로젝트를 삭제할 수 있는 기능
+
+### 엔드포인트
+```
+DELETE /projects/{projectId}
+🔒 Authorization Required
+```
+
+### Response (204)
+No Content
+
+### 에러 응답
+| Status | Description |
+|--------|-------------|
+| 403 | 권한 없음 (본인 프로젝트가 아님) |
+| 404 | 프로젝트 없음 |
+
+### 사용처
+- 프로젝트 목록 페이지 (삭제 버튼)
+- 프로젝트 설정 페이지
+
+---
+
+## 3. 위저드 단계 정의 조회 API 🟠
+
+### 요청 사항
+템플릿별 위저드 단계 및 질문 정의 조회
+
+### 배경
+현재 프론트엔드에서 `mockData.ts`의 하드코딩된 `wizardSteps`를 사용 중.
+템플릿마다 다른 질문 세트가 필요할 수 있음.
+
+### 엔드포인트
+```
+GET /projects/{projectId}/wizard/steps
+🔒 Authorization Required
+```
+
+또는 템플릿 기반:
+```
+GET /templates/{templateCode}/wizard/steps
+```
+
+### Response (200)
+```json
+{
+  "templateCode": "pre-startup",
+  "totalSteps": 5,
+  "steps": [
+    {
+      "id": 1,
+      "title": "사업 아이디어",
+      "description": "사업 아이디어를 설명해주세요",
+      "questions": [
+        {
+          "id": "business-name",
+          "type": "text",
+          "label": "사업명",
+          "placeholder": "사업명을 입력하세요",
+          "required": true,
+          "maxLength": 100
+        },
+        {
+          "id": "business-description",
+          "type": "textarea",
+          "label": "사업 설명",
+          "placeholder": "사업 아이디어를 설명해주세요",
+          "required": true,
+          "maxLength": 1000
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "목표 시장",
+      "description": "목표 시장을 정의해주세요",
+      "questions": [...]
+    }
+  ]
+}
+```
+
+### Question Type 정의
+| Type | Description |
+|------|-------------|
+| `text` | 한 줄 텍스트 입력 |
+| `textarea` | 여러 줄 텍스트 입력 |
+| `number` | 숫자 입력 |
+| `select` | 단일 선택 (드롭다운) |
+| `multiselect` | 복수 선택 |
+| `date` | 날짜 선택 |
+| `radio` | 라디오 버튼 |
+
+### 사용처
+- WizardStep 컴포넌트
+- QuestionForm 컴포넌트
+
+---
+
+## 4. 재무 데이터 조회 API 🟠
+
+### 요청 사항
+저장된 재무 시뮬레이션 데이터 조회
+
+### 배경
+현재 `/financials/generate`만 있고, 이전에 생성한 재무 데이터를 조회하는 API가 없음.
+재접속 시 마지막 시뮬레이션 결과를 표시해야 함.
+
+### 엔드포인트
+```
+GET /projects/{projectId}/financials
+🔒 Authorization Required
+```
+
+### Response (200)
+```json
+{
+  "projectId": "project-uuid",
+  "assumptions": {
+    "initialCapital": 50000000,
+    "averageRevenuePerUser": 30000,
+    "monthlyMarketingBudget": 5000000,
+    "customerAcquisitionCost": 10000,
+    "monthlyChurnRate": 0.05,
+    "monthlyFixedCosts": 10000000
+  },
+  "monthlyPL": [...],
+  "yearlySummary": [...],
+  "unitEconomics": {
+    "ltv": 600000,
+    "cac": 10000,
+    "ltvCacRatio": 60,
+    "paybackPeriodMonths": 3
+  },
+  "createdAt": "2025-01-01T12:00:00",
+  "updatedAt": "2025-01-01T12:00:00"
+}
+```
+
+### Response (404)
+재무 데이터가 없는 경우
+```json
+{
+  "message": "재무 데이터가 없습니다."
+}
+```
+
+### 사용처
+- FinancialSimulation 컴포넌트 (초기 로드)
+- 사업계획서 재무 섹션
+
+---
+
+## 5. 재무 데이터 저장 API 🟠
+
+### 요청 사항
+재무 가정값만 저장 (시뮬레이션 재실행 없이)
+
+### 배경
+현재 `/financials/generate`는 항상 시뮬레이션을 다시 실행함.
+가정값만 저장하고 싶을 때 사용.
+
+### 엔드포인트
+```
+PUT /projects/{projectId}/financials/assumptions
+🔒 Authorization Required
+```
+
+### Request Body
+```json
+{
+  "initialCapital": 50000000,
+  "averageRevenuePerUser": 30000,
+  "monthlyMarketingBudget": 5000000,
+  "customerAcquisitionCost": 10000,
+  "monthlyChurnRate": 0.05,
+  "monthlyFixedCosts": 10000000,
+  "variableCostRate": 0.3,
+  "initialCustomers": 100,
+  "projectionMonths": 36
+}
+```
+
+### Response (200)
+```json
+{
+  "message": "저장되었습니다.",
+  "updatedAt": "2025-01-01T12:00:00"
+}
+```
+
+### 사용처
+- 자동 저장 기능 (Auto-save)
+- 임시 저장 버튼
+
+---
+
+## 6. PMF 설문 질문 조회 API 🟡
+
+### 요청 사항
+PMF(Product-Market Fit) 진단용 설문 질문 목록 조회
+
+### 엔드포인트
+```
+GET /pmf/questions
+```
+
+또는 템플릿별:
+```
+GET /templates/{templateCode}/pmf/questions
+```
+
+### Response (200)
+```json
+{
+  "questions": [
+    {
+      "id": "pmf-1",
+      "question": "만약 이 제품을 더 이상 사용할 수 없게 된다면 어떻게 느끼시겠습니까?",
+      "type": "radio",
+      "required": true,
+      "options": [
+        { "value": 1, "label": "매우 실망할 것이다" },
+        { "value": 2, "label": "다소 실망할 것이다" },
+        { "value": 3, "label": "실망하지 않을 것이다" },
+        { "value": 4, "label": "해당 없음" }
+      ]
+    },
+    {
+      "id": "pmf-2",
+      "question": "이 제품의 주요 혜택은 무엇입니까?",
+      "type": "multiselect",
+      "required": true,
+      "options": [
+        { "value": 1, "label": "시간 절약" },
+        { "value": 2, "label": "비용 절감" },
+        { "value": 3, "label": "품질 향상" },
+        { "value": 4, "label": "기타" }
+      ]
+    }
+  ]
+}
+```
+
+### 사용처
+- PMFSurvey 컴포넌트
+- 위저드 5단계
+
+---
+
+## 7. PMF 설문 결과 제출 API 🟡
+
+### 요청 사항
+PMF 설문 답변 제출 및 분석 결과 생성
+
+### 엔드포인트
+```
+POST /projects/{projectId}/pmf/submit
+🔒 Authorization Required
+```
+
+### Request Body
+```json
+{
+  "answers": [
+    { "questionId": "pmf-1", "value": 1 },
+    { "questionId": "pmf-2", "value": [1, 2] },
+    { "questionId": "pmf-3", "value": 1 }
+  ]
+}
+```
+
+### Response (200)
+```json
+{
+  "projectId": "project-uuid",
+  "score": 42,
+  "level": "excellent",
+  "risks": [
+    {
+      "id": "risk-1",
+      "title": "시장 검증 필요",
+      "description": "더 많은 고객 피드백이 필요합니다.",
+      "severity": "medium"
+    }
+  ],
+  "recommendations": [
+    {
+      "id": "rec-1",
+      "title": "고객 인터뷰 진행",
+      "description": "핵심 고객층과 심층 인터뷰를 진행하세요.",
+      "priority": "high"
+    }
+  ],
+  "createdAt": "2025-01-01T12:00:00"
+}
+```
+
+### PMF Level 정의
+| Level | Score 범위 | 설명 |
+|-------|-----------|------|
+| `excellent` | 40% 이상 | PMF 달성 |
+| `high` | 30-39% | 거의 달성 |
+| `medium` | 20-29% | 개선 필요 |
+| `low` | 20% 미만 | PMF 미달성 |
+
+### 사용처
+- PMFSurvey 컴포넌트 (결과 제출)
+
+---
+
+## 8. PMF 리포트 조회 API 🟡
+
+### 요청 사항
+저장된 PMF 분석 결과 조회
+
+### 엔드포인트
+```
+GET /projects/{projectId}/pmf/report
+🔒 Authorization Required
+```
+
+### Response (200)
+```json
+{
+  "projectId": "project-uuid",
+  "score": 42,
+  "level": "excellent",
+  "risks": [...],
+  "recommendations": [...],
+  "answers": [
+    { "questionId": "pmf-1", "value": 1 },
+    { "questionId": "pmf-2", "value": [1, 2] }
+  ],
+  "createdAt": "2025-01-01T12:00:00"
+}
+```
+
+### Response (404)
+PMF 리포트가 없는 경우
+```json
+{
+  "message": "PMF 리포트가 없습니다."
+}
+```
+
+### 사용처
+- PMFSurvey 컴포넌트 (이전 결과 로드)
+- 사업계획서 PMF 섹션
+
+---
+
+## 추가 고려사항
+
+### 1. 버전 관리
+현재 API prefix가 `/api/v1`과 없는 것이 혼재됨.
+- Auth/Users: `/api/v1/auth/*`, `/api/v1/users/*`
+- Projects/Wizard: `/projects/*`
+
+**권장**: 일관된 버전 prefix 사용
+```
+/api/v1/projects/{projectId}/...
+```
+
+### 2. 에러 응답 형식 통일
+```json
+{
+  "timestamp": "2025-01-01T12:00:00",
+  "status": 400,
+  "error": "Bad Request",
+  "message": "에러 메시지",
+  "path": "/api/v1/..."
+}
+```
+
+### 3. 페이지네이션 (프로젝트 목록)
+현재 `/projects`가 배열을 직접 반환하는데, 프로젝트가 많아지면 페이지네이션 필요:
+```json
+{
+  "data": [...],
+  "meta": {
+    "page": 1,
+    "limit": 20,
+    "total": 100,
+    "totalPages": 5
+  }
+}
+```
+
+---
+
+## 우선순위별 개발 일정 제안
+
+| 단계 | API | 예상 공수 |
+|------|-----|----------|
+| **Phase 1** | 프로젝트 수정/삭제 | 0.5일 |
+| **Phase 2** | 재무 데이터 조회/저장 | 1일 |
+| **Phase 3** | 위저드 단계 정의 조회 | 1일 |
+| **Phase 4** | PMF 전체 (질문/제출/리포트) | 2일 |
+
+---
+
+## 문의
+
+추가 질문이나 스펙 변경이 필요하면 연락 부탁드립니다.
+
+- Swagger 문서: http://localhost:8080/swagger-ui.html
+- 기존 API 문서: [API-REFERENCE.md](./API-REFERENCE.md)
+

--- a/tasks/functional/EPIC0-FE-006.md
+++ b/tasks/functional/EPIC0-FE-006.md
@@ -1,0 +1,79 @@
+# EPIC0-FE-006: 회원가입 및 로그인 인증 UI PoC
+
+## 1. 개요
+- **목표**: 사용자가 이메일/비밀번호로 회원가입 및 로그인할 수 있는 인증 화면을 구현하고, JWT 토큰 기반 인증 흐름을 연동한다.
+- **범위**:
+  - 회원가입 페이지 (이메일, 비밀번호, 비밀번호 확인)
+  - 로그인 페이지 (이메일, 비밀번호)
+  - JWT 토큰 저장 및 관리 (localStorage 또는 httpOnly Cookie)
+  - 인증 상태에 따른 라우트 보호 (Protected Route)
+  - 자동 토큰 갱신 (Refresh Token)
+- **Out of Scope**: 소셜 로그인(OAuth), 비밀번호 찾기/재설정.
+
+## 2. 상세 요구사항
+- **회원가입**: 이메일 형식 검증, 비밀번호 8자 이상 + 숫자/특수문자 포함 검증, 비밀번호 확인 일치 검증.
+- **로그인**: 이메일/비밀번호 입력 후 API 호출, 실패 시 에러 메시지 표시.
+- **토큰 관리**: 로그인 성공 시 Access Token과 Refresh Token 저장, API 요청 시 Authorization 헤더에 자동 추가.
+- **인증 상태**: `useAuthStore`를 통해 로그인 상태를 전역 관리하고, 비로그인 시 보호된 페이지 접근 차단.
+- **자동 로그아웃**: Access Token 만료 시 Refresh Token으로 갱신 시도, 실패 시 로그인 페이지로 리다이렉트.
+
+## 3. 기술 스택 및 도구
+- React + Vite + TypeScript
+- React Hook Form + Zod (폼 검증)
+- Zustand (인증 상태 관리)
+- Axios Interceptor (토큰 자동 첨부 및 갱신)
+
+---
+
+```yaml
+task_id: "EPIC0-FE-006"
+title: "회원가입 및 로그인 인증 UI PoC 구현"
+summary: >
+  이메일/비밀번호 기반 회원가입, 로그인 화면을 구현하고,
+  JWT 토큰 인증 흐름과 Protected Route를 적용한다.
+type: "functional"
+
+epic: "EPIC_0_FE_PROTOTYPE"
+req_ids: ["REQ-FUNC-AUTH", "REQ-NF-AUTH-001"]
+agent_profile: ["frontend"]
+
+parallelizable: true
+estimated_effort: "M"
+priority: "Must"
+
+inputs:
+  description: "사용자 인증 정보"
+  fields:
+    - name: "email"
+      type: "string"
+      example: "user@example.com"
+    - name: "password"
+      type: "string"
+      example: "SecurePass123!"
+
+outputs:
+  description: "JWT 토큰 및 인증 상태"
+  success:
+    tokens: { accessToken: "string", refreshToken: "string" }
+    ui_state: "Authenticated User Redirect to Dashboard"
+
+steps_hint:
+  - "SignupPage 컴포넌트 구현 (폼 검증 포함)"
+  - "LoginPage 컴포넌트 구현"
+  - "useAuthStore 구현 (login, logout, refreshToken 액션)"
+  - "Axios Interceptor 설정 (토큰 자동 첨부, 401 처리)"
+  - "ProtectedRoute 컴포넌트 구현"
+  - "AuthController API 연동 (/api/v1/auth/*)"
+
+preconditions:
+  - "React+Vite 기본 프로젝트가 셋업되어 있어야 한다."
+  - "백엔드 AuthController API가 구현되어 있어야 한다."
+
+postconditions:
+  - "회원가입 성공 시 로그인 페이지로 이동한다."
+  - "로그인 성공 시 대시보드(프로젝트 목록)로 이동한다."
+  - "비로그인 상태에서 보호된 페이지 접근 시 로그인으로 리다이렉트된다."
+  - "Access Token 만료 시 자동으로 갱신을 시도한다."
+
+dependencies: []
+```

--- a/tasks/functional/EPIC0-FE-007.md
+++ b/tasks/functional/EPIC0-FE-007.md
@@ -1,0 +1,74 @@
+# EPIC0-FE-007: 사용자 프로필 관리 UI PoC
+
+## 1. 개요
+- **목표**: 로그인한 사용자가 자신의 프로필을 조회/수정하고, 비밀번호 변경 및 회원 탈퇴를 할 수 있는 화면을 구현한다.
+- **범위**:
+  - 프로필 조회 페이지 (내 정보 확인)
+  - 프로필 수정 폼 (이름, 연락처 등)
+  - 비밀번호 변경 폼
+  - 회원 탈퇴 확인 모달
+- **Out of Scope**: 프로필 이미지 업로드, 이메일 변경.
+
+## 2. 상세 요구사항
+- **프로필 조회**: 현재 사용자의 이메일, 이름, 가입일 등 표시.
+- **프로필 수정**: 이름, 연락처 등 편집 가능 필드 제공, 저장 시 실시간 피드백.
+- **비밀번호 변경**: 현재 비밀번호 확인 → 새 비밀번호 입력 → 확인, 강도 표시기(Strength Meter) 포함.
+- **회원 탈퇴**: 비밀번호 재확인 후 탈퇴 처리, 탈퇴 전 경고 모달 표시.
+- **접근 제어**: 인증된 사용자만 접근 가능 (ProtectedRoute).
+
+## 3. 기술 스택 및 도구
+- React Hook Form + Zod (폼 검증)
+- UI Components (Modal, Toast 알림)
+- useAuthStore (현재 사용자 정보)
+
+---
+
+```yaml
+task_id: "EPIC0-FE-007"
+title: "사용자 프로필 관리 UI PoC 구현"
+summary: >
+  로그인한 사용자의 프로필 조회/수정, 비밀번호 변경,
+  회원 탈퇴 기능을 제공하는 설정 페이지를 구현한다.
+type: "functional"
+
+epic: "EPIC_0_FE_PROTOTYPE"
+req_ids: ["REQ-FUNC-USER", "REQ-NF-SEC-001"]
+agent_profile: ["frontend"]
+
+parallelizable: true
+estimated_effort: "S"
+priority: "Should"
+
+inputs:
+  description: "사용자 프로필 및 비밀번호 정보"
+  fields:
+    - name: "displayName"
+      type: "string"
+    - name: "currentPassword"
+      type: "string"
+    - name: "newPassword"
+      type: "string"
+
+outputs:
+  description: "업데이트된 프로필 정보"
+  success:
+    ui_state: "Profile Updated, Toast Notification"
+
+steps_hint:
+  - "ProfilePage 컴포넌트 구현 (탭 형태: 프로필, 보안)"
+  - "ProfileEditForm 컴포넌트 구현"
+  - "ChangePasswordForm 컴포넌트 구현 (Strength Meter 포함)"
+  - "DeleteAccountModal 컴포넌트 구현"
+  - "UserController API 연동 (/api/v1/users/me)"
+
+preconditions:
+  - "EPIC0-FE-006의 인증 흐름이 구현되어 있어야 한다."
+  - "백엔드 UserController API가 구현되어 있어야 한다."
+
+postconditions:
+  - "프로필 수정 성공 시 성공 토스트 메시지가 표시된다."
+  - "비밀번호 변경 성공 시 재로그인을 요청한다."
+  - "회원 탈퇴 완료 시 로그아웃 후 홈으로 이동한다."
+
+dependencies: ["EPIC0-FE-006"]
+```

--- a/tasks/functional/EPIC0-FE-008.md
+++ b/tasks/functional/EPIC0-FE-008.md
@@ -1,0 +1,74 @@
+# EPIC0-FE-008: 프로젝트 대시보드 및 목록 관리 UI PoC
+
+## 1. 개요
+- **목표**: 로그인한 사용자가 자신의 프로젝트 목록을 조회하고, 각 프로젝트의 상태를 한눈에 파악할 수 있는 대시보드를 구현한다.
+- **범위**:
+  - 프로젝트 목록 페이지 (카드 또는 테이블 레이아웃)
+  - 프로젝트 상태 표시 (진행 중, 완료, 초안 등)
+  - 프로젝트 검색 및 필터링
+  - 프로젝트 정렬 (최근 수정일, 생성일)
+  - 빈 상태(Empty State) UI
+- **Out of Scope**: 프로젝트 삭제/복사, 팀 공유 기능.
+
+## 2. 상세 요구사항
+- **목록 표시**: 각 프로젝트 카드에 제목, 템플릿 유형, 상태, 마지막 수정일, 완료율(Progress) 표시.
+- **빈 상태**: 프로젝트가 없을 경우 "새 프로젝트 만들기" CTA 버튼과 안내 문구 표시.
+- **검색**: 프로젝트 제목으로 필터링 (클라이언트 사이드).
+- **정렬**: 드롭다운으로 정렬 기준 선택 (최근 수정순, 생성순, 이름순).
+- **상태 필터**: 전체, 진행 중, 완료 탭 제공.
+- **프로젝트 진입**: 카드 클릭 시 해당 프로젝트 Wizard 또는 문서 뷰어로 이동.
+
+## 3. 기술 스택 및 도구
+- React + TypeScript
+- TanStack Query (React Query) - 데이터 페칭 및 캐싱
+- UI Components (Card, Badge, SearchInput, Dropdown)
+
+---
+
+```yaml
+task_id: "EPIC0-FE-008"
+title: "프로젝트 대시보드 및 목록 관리 UI PoC 구현"
+summary: >
+  사용자의 프로젝트 목록을 카드 형태로 표시하고,
+  검색/필터/정렬 기능을 제공하는 대시보드를 구현한다.
+type: "functional"
+
+epic: "EPIC_0_FE_PROTOTYPE"
+req_ids: ["REQ-FUNC-001", "REQ-FUNC-014"]
+agent_profile: ["frontend"]
+
+parallelizable: true
+estimated_effort: "M"
+priority: "Must"
+
+inputs:
+  description: "프로젝트 목록 API 응답"
+  fields:
+    - name: "projects"
+      type: "array"
+      example: [{projectId: "proj_123", title: "예비창업 1호", status: "IN_PROGRESS"}]
+
+outputs:
+  description: "프로젝트 대시보드 UI"
+  success:
+    ui_state: "Project List with Filters"
+
+steps_hint:
+  - "DashboardPage 컴포넌트 구현"
+  - "ProjectCard 컴포넌트 구현 (상태 뱃지, 진행률 바 포함)"
+  - "SearchBar 및 SortDropdown 컴포넌트 구현"
+  - "EmptyState 컴포넌트 구현 (CTA 버튼 포함)"
+  - "useProjects 훅 구현 (React Query 연동)"
+  - "ProjectController API 연동 (GET /projects)"
+
+preconditions:
+  - "EPIC0-FE-006의 인증 흐름이 구현되어 있어야 한다."
+  - "EPIC0-FE-001의 프로젝트 생성 기능이 구현되어 있어야 한다."
+
+postconditions:
+  - "로그인 후 대시보드에서 자신의 프로젝트 목록을 볼 수 있다."
+  - "프로젝트 카드 클릭 시 해당 프로젝트 페이지로 이동한다."
+  - "검색어 입력 시 실시간으로 목록이 필터링된다."
+
+dependencies: ["EPIC0-FE-006", "EPIC0-FE-001"]
+```

--- a/tasks/functional/EPIC0-FE-009.md
+++ b/tasks/functional/EPIC0-FE-009.md
@@ -1,0 +1,70 @@
+# EPIC0-FE-009: 문서 버전 관리 및 히스토리 UI PoC
+
+## 1. 개요
+- **목표**: 생성된 사업계획서의 버전 목록을 조회하고, 특정 버전을 선택하여 비교하거나 복원할 수 있는 화면을 구현한다.
+- **범위**:
+  - 문서 버전 목록 패널 (사이드바 또는 드롭다운)
+  - 버전별 생성 일시, 변경 내용 요약 표시
+  - 특정 버전 선택 시 해당 버전 내용 미리보기
+  - 버전 비교 뷰 (Diff View) - 간단한 텍스트 비교
+- **Out of Scope**: 버전 병합(Merge), 협업 편집 기능.
+
+## 2. 상세 요구사항
+- **버전 목록**: 버전 번호, 생성 일시, 상태(DRAFT/COMPLETED) 표시.
+- **현재 버전 표시**: 최신 버전에 "현재" 뱃지 표시.
+- **버전 선택**: 클릭 시 해당 버전의 문서 내용을 뷰어에 로드.
+- **섹션 재생성**: 특정 섹션의 "AI 다시 쓰기" 버튼 클릭 시 해당 섹션만 재생성 (새 버전 생성).
+- **버전 비교**: 두 버전 선택 시 변경된 부분 하이라이트 (선택적 기능).
+
+## 3. 기술 스택 및 도구
+- React + TypeScript
+- Diff 라이브러리 (diff, react-diff-viewer 등)
+- UI Components (Timeline, Badge)
+
+---
+
+```yaml
+task_id: "EPIC0-FE-009"
+title: "문서 버전 관리 및 히스토리 UI PoC 구현"
+summary: >
+  사업계획서의 버전 목록을 표시하고, 버전 선택/비교
+  기능을 제공하는 버전 관리 UI를 구현한다.
+type: "functional"
+
+epic: "EPIC_0_FE_PROTOTYPE"
+req_ids: ["REQ-FUNC-003", "REQ-FUNC-005"]
+agent_profile: ["frontend"]
+
+parallelizable: true
+estimated_effort: "S"
+priority: "Should"
+
+inputs:
+  description: "문서 버전 목록"
+  fields:
+    - name: "versions"
+      type: "array"
+      example: [{version: 1, createdAt: "2025-01-01T10:00:00Z", status: "COMPLETED"}]
+
+outputs:
+  description: "버전 히스토리 UI"
+  success:
+    ui_state: "Version List with Preview"
+
+steps_hint:
+  - "VersionHistoryPanel 컴포넌트 구현 (사이드바 형태)"
+  - "VersionListItem 컴포넌트 구현"
+  - "버전 선택 시 DocumentViewer에 해당 내용 로드"
+  - "SectionRegenerateButton 컴포넌트 구현"
+  - "BusinessPlanController API 연동 (/projects/{id}/documents/business-plan/versions)"
+
+preconditions:
+  - "EPIC0-FE-003의 문서 뷰어가 구현되어 있어야 한다."
+  - "백엔드 BusinessPlanController API가 구현되어 있어야 한다."
+
+postconditions:
+  - "버전 목록에서 과거 버전을 선택하면 해당 내용이 표시된다."
+  - "섹션 재생성 시 새 버전이 생성되고 목록에 추가된다."
+
+dependencies: ["EPIC0-FE-003"]
+```

--- a/tasks/functional/EPIC0-FE-010.md
+++ b/tasks/functional/EPIC0-FE-010.md
@@ -1,0 +1,76 @@
+# EPIC0-FE-010: 문서 내보내기 실제 구현 UI PoC
+
+## 1. 개요
+- **목표**: 생성된 사업계획서를 PDF 또는 HTML 형식으로 실제 다운로드할 수 있는 기능을 구현한다. (FE-003의 Mock에서 실제 연동으로 확장)
+- **범위**:
+  - 내보내기 형식 선택 드롭다운 (PDF, HTML)
+  - 다운로드 진행 상태 표시 (로딩 인디케이터)
+  - 다운로드 완료/실패 토스트 알림
+  - 지원 형식 안내 (HWP 향후 지원 예정 메시지)
+  - 특정 버전 내보내기 옵션
+- **Out of Scope**: HWP 형식 실제 구현, 인쇄 기능.
+
+## 2. 상세 요구사항
+- **형식 선택**: PDF(기본), HTML 선택 가능, 각 형식 아이콘 표시.
+- **다운로드 흐름**: 버튼 클릭 → 로딩 표시 → 파일 다운로드 트리거 → 완료 토스트.
+- **에러 처리**: 문서 없음(404), 서버 오류(500) 등에 대한 에러 메시지 표시.
+- **버전 선택**: 현재 버전 또는 특정 버전 선택 후 내보내기.
+- **파일명**: "프로젝트명_사업계획서_v버전.pdf" 형태로 자동 생성.
+
+## 3. 기술 스택 및 도구
+- File Download 처리 (Blob, createObjectURL)
+- Axios (바이너리 데이터 처리)
+- UI Components (Dropdown, Toast, LoadingSpinner)
+
+---
+
+```yaml
+task_id: "EPIC0-FE-010"
+title: "문서 내보내기 실제 구현 UI PoC 구현"
+summary: >
+  사업계획서를 PDF/HTML 형식으로 실제 다운로드하는
+  기능을 구현하고, 형식 선택 및 버전 옵션을 제공한다.
+type: "functional"
+
+epic: "EPIC_0_FE_PROTOTYPE"
+req_ids: ["REQ-FUNC-011", "REQ-FUNC-006"]
+agent_profile: ["frontend"]
+
+parallelizable: true
+estimated_effort: "S"
+priority: "Must"
+
+inputs:
+  description: "내보내기 옵션"
+  fields:
+    - name: "format"
+      type: "string"
+      example: "pdf"
+    - name: "version"
+      type: "number"
+      example: 1
+
+outputs:
+  description: "다운로드된 파일"
+  success:
+    file: "사업계획서_v1.pdf"
+
+steps_hint:
+  - "ExportButton 컴포넌트를 ExportDropdown으로 확장"
+  - "FormatSelector 컴포넌트 구현"
+  - "useExportDocument 훅 구현 (Blob 처리 포함)"
+  - "downloadFile 유틸 함수 구현 (createObjectURL)"
+  - "ExportController API 연동 (GET /projects/{id}/export)"
+  - "에러 핸들링 및 토스트 알림 연동"
+
+preconditions:
+  - "EPIC0-FE-003의 문서 뷰어가 구현되어 있어야 한다."
+  - "백엔드 ExportController API가 구현되어 있어야 한다."
+
+postconditions:
+  - "PDF 선택 시 PDF 파일이 다운로드된다."
+  - "HTML 선택 시 HTML 파일이 다운로드된다."
+  - "다운로드 실패 시 에러 토스트가 표시된다."
+
+dependencies: ["EPIC0-FE-003"]
+```

--- a/tasks/functional/EPIC0-FE-011.md
+++ b/tasks/functional/EPIC0-FE-011.md
@@ -1,0 +1,80 @@
+# EPIC0-FE-011: 공통 컴포넌트 및 전역 에러 핸들링 UI PoC
+
+## 1. 개요
+- **목표**: 애플리케이션 전반에서 사용되는 공통 UI 컴포넌트와 전역 에러 핸들링 시스템을 구현한다.
+- **범위**:
+  - Toast 알림 시스템 (성공, 에러, 경고, 정보)
+  - 전역 에러 바운더리 (React Error Boundary)
+  - 404 Not Found 페이지
+  - 500 Server Error 페이지
+  - API 에러 핸들링 유틸리티
+  - 로딩 상태 컴포넌트 (Spinner, Skeleton)
+  - 공통 모달 컴포넌트
+- **Out of Scope**: 디자인 시스템 전체 구축, 테마 시스템.
+
+## 2. 상세 요구사항
+- **Toast 시스템**: 화면 우상단에 스택형 토스트 표시, 자동 사라짐(3초), 수동 닫기 지원.
+- **에러 바운더리**: 예기치 않은 렌더링 오류 시 폴백 UI 표시, 에러 리포트 버튼 제공.
+- **404 페이지**: 친근한 일러스트와 함께 홈으로 돌아가기 CTA.
+- **500 페이지**: "문제가 발생했습니다" 메시지, 다시 시도/홈으로 버튼.
+- **API 에러**: 상태 코드별 메시지 매핑 (400: 입력 오류, 401: 재로그인 필요, 403: 권한 없음, 404: 찾을 수 없음, 500: 서버 오류).
+- **로딩 컴포넌트**: Spinner(버튼용), Skeleton(카드/리스트용), FullPageLoader(페이지 전환용).
+
+## 3. 기술 스택 및 도구
+- React Error Boundary
+- React-Hot-Toast 또는 Sonner (토스트)
+- Zustand 또는 Context (전역 상태)
+- Tailwind CSS (스타일링)
+
+---
+
+```yaml
+task_id: "EPIC0-FE-011"
+title: "공통 컴포넌트 및 전역 에러 핸들링 UI PoC 구현"
+summary: >
+  Toast 알림, 에러 페이지, API 에러 핸들링 등
+  애플리케이션 전반에서 사용하는 공통 UI 인프라를 구축한다.
+type: "functional"
+
+epic: "EPIC_0_FE_PROTOTYPE"
+req_ids: ["REQ-NF-006-SEC", "REQ-NF-012-OPS"]
+agent_profile: ["frontend"]
+
+parallelizable: true
+estimated_effort: "M"
+priority: "Must"
+
+inputs:
+  description: "에러 및 알림 데이터"
+  fields:
+    - name: "error"
+      type: "object"
+      example: { code: 400, message: "잘못된 입력입니다" }
+    - name: "toast"
+      type: "object"
+      example: { type: "success", message: "저장되었습니다" }
+
+outputs:
+  description: "공통 UI 컴포넌트 라이브러리"
+  success:
+    components: ["Toast", "ErrorBoundary", "NotFoundPage", "ServerErrorPage", "LoadingSpinner", "Modal"]
+
+steps_hint:
+  - "ToastProvider 및 useToast 훅 구현"
+  - "GlobalErrorBoundary 컴포넌트 구현"
+  - "NotFoundPage (404) 컴포넌트 구현"
+  - "ServerErrorPage (500) 컴포넌트 구현"
+  - "apiErrorHandler 유틸 함수 구현 (Axios Interceptor 연동)"
+  - "LoadingSpinner, SkeletonCard, FullPageLoader 컴포넌트 구현"
+  - "ConfirmModal, AlertModal 공통 모달 구현"
+
+preconditions:
+  - "React+Vite 기본 프로젝트가 셋업되어 있어야 한다."
+
+postconditions:
+  - "API 오류 발생 시 적절한 토스트 메시지가 표시된다."
+  - "렌더링 오류 발생 시 폴백 UI가 표시된다."
+  - "존재하지 않는 URL 접근 시 404 페이지가 표시된다."
+
+dependencies: []
+```

--- a/tasks/functional/EPIC0-FE-012.md
+++ b/tasks/functional/EPIC0-FE-012.md
@@ -1,0 +1,75 @@
+# EPIC0-FE-012: 재무 추정 미리보기 (독립형) UI PoC
+
+## 1. 개요
+- **목표**: 프로젝트 생성 없이 재무 추정 결과를 미리 확인할 수 있는 독립형 계산기 페이지를 구현한다. 사용자가 프로젝트 생성 전에 재무 시뮬레이션을 경험할 수 있도록 한다.
+- **범위**:
+  - 랜딩 페이지 또는 별도 메뉴에서 접근 가능한 재무 계산기
+  - 프로젝트 연동 없는 독립 실행 모드
+  - 계산 결과 시각화 (BEP, LTV/CAC 차트)
+  - "프로젝트로 저장하기" CTA 버튼 (로그인 유도)
+- **Out of Scope**: 계산 결과 저장(비로그인), 고급 재무 모델링.
+
+## 2. 상세 요구사항
+- **접근성**: 비로그인 사용자도 접근 가능.
+- **입력 폼**: 초기 자본, 월 고정비, 객단가(ARPU), 고객 획득 비용(CAC), 이탈률 등 핵심 변수 입력.
+- **실시간 계산**: 입력 값 변경 시 즉시 결과 업데이트 (Debounce 적용).
+- **결과 시각화**: 손익분기점 월, 예상 수익 그래프, LTV/CAC 비율 게이지.
+- **CTA**: "이 설정으로 프로젝트 시작하기" 버튼 → 로그인/회원가입 유도 → 프로젝트 생성 시 값 자동 채우기.
+
+## 3. 기술 스택 및 도구
+- React + TypeScript
+- Recharts (차트)
+- Zustand (임시 상태 저장)
+- API: /financials/preview
+
+---
+
+```yaml
+task_id: "EPIC0-FE-012"
+title: "재무 추정 미리보기 (독립형) UI PoC 구현"
+summary: >
+  비로그인 사용자도 접근 가능한 독립형 재무 계산기를 구현하고,
+  계산 결과를 프로젝트로 연결하는 전환 흐름을 제공한다.
+type: "functional"
+
+epic: "EPIC_0_FE_PROTOTYPE"
+req_ids: ["REQ-FUNC-009", "REQ-FUNC-015"]
+agent_profile: ["frontend"]
+
+parallelizable: true
+estimated_effort: "S"
+priority: "Could"
+
+inputs:
+  description: "재무 가정 변수 (프로젝트 미연동)"
+  fields:
+    - name: "initialCapital"
+      type: "number"
+    - name: "averageRevenuePerUser"
+      type: "number"
+    - name: "customerAcquisitionCost"
+      type: "number"
+
+outputs:
+  description: "재무 미리보기 결과"
+  success:
+    ui_state: "Preview Charts without Save"
+
+steps_hint:
+  - "FinancialCalculatorPage 컴포넌트 구현 (Public Route)"
+  - "PreviewFinancialForm 컴포넌트 구현"
+  - "FinancialPreviewController API 연동 (POST /financials/preview)"
+  - "결과 차트 재사용 (EPIC0-FE-004 컴포넌트)"
+  - "CTABanner 컴포넌트 구현 (로그인 유도)"
+  - "URL 파라미터로 초기값 전달 기능 (선택)"
+
+preconditions:
+  - "EPIC0-FE-004의 재무 시각화 컴포넌트가 구현되어 있어야 한다."
+  - "백엔드 FinancialPreviewController API가 구현되어 있어야 한다."
+
+postconditions:
+  - "비로그인 상태에서도 재무 계산 결과를 확인할 수 있다."
+  - "'프로젝트로 저장하기' 클릭 시 로그인 페이지로 이동하고, 로그인 후 값이 유지된다."
+
+dependencies: ["EPIC0-FE-004"]
+```


### PR DESCRIPTION
## 개요
사업계획서 섹션을 AI Engine을 통해 생성하는 API를 구현합니다.

## 변경 내용
- `BizPlanSectionController`: 섹션 AI 생성 및 CRUD API 추가
- `BizPlanSectionService`: AI Engine 연동 로직 구현
- `BizPlanSection` 엔티티 및 Repository 추가
- V6 마이그레이션: `bizplan_sections` 테이블 생성
- Request/Response DTO 추가
- Swagger 문서화 완료

## API 엔드포인트
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/projects/{projectId}/bizplan/sections/{sectionType}/generate` | AI 섹션 생성 |
| GET | `/projects/{projectId}/bizplan/sections` | 섹션 목록 조회 |
| GET | `/projects/{projectId}/bizplan/sections/{sectionType}` | 섹션 조회 |
| PUT | `/projects/{projectId}/bizplan/sections/{sectionType}` | 섹션 수정 |
| DELETE | `/projects/{projectId}/bizplan/sections/{sectionType}` | 섹션 삭제 |

## 테스트
- 컴파일 성공 확인

Closes #62