### PR TITLE
[BE-AI-003] PMF AI 진단 API 연동

### DIFF
--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/PmfController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/PmfController.java
@@ -1,7 +1,9 @@
 package com.vibe.bizplan.bizplan_be.api;
 
 import com.vibe.bizplan.bizplan_be.domain.service.PmfService;
+import com.vibe.bizplan.bizplan_be.dto.request.AiPmfDiagnoseRequest;
 import com.vibe.bizplan.bizplan_be.dto.request.PmfSubmitRequest;
+import com.vibe.bizplan.bizplan_be.dto.response.AiPmfDiagnoseResponse;
 import com.vibe.bizplan.bizplan_be.dto.response.PmfQuestionsResponse;
 import com.vibe.bizplan.bizplan_be.dto.response.PmfReportResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -97,6 +99,71 @@ public class PmfController {
                 })
                 .orElseGet(() -> {
                     log.info("PMF 리포트 없음 - projectId={}", projectId);
+                    return ResponseEntity.notFound().build();
+                });
+    }
+
+    /**
+     * AI 기반 PMF 진단.
+     * 사업계획서 내용과 재무 데이터를 AI로 분석하여 PMF를 진단합니다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param request 진단 요청 (선택)
+     * @return AI PMF 진단 결과
+     */
+    @PostMapping("/projects/{projectId}/pmf/ai-diagnose")
+    @Operation(
+            summary = "AI PMF 진단",
+            description = "사업계획서 내용과 재무 데이터를 AI로 분석하여 PMF를 진단합니다. " +
+                    "설문 기반 진단과 달리 AI가 자동으로 분석하여 점수, 리스크, 추천 사항을 제공합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "진단 완료",
+                    content = @Content(schema = @Schema(implementation = AiPmfDiagnoseResponse.class))),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "AI 엔진 오류")
+    })
+    public ResponseEntity<AiPmfDiagnoseResponse> aiDiagnose(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId,
+            @Valid @RequestBody(required = false) AiPmfDiagnoseRequest request
+    ) {
+        log.info("POST /projects/{}/pmf/ai-diagnose - includeFinancialData={}",
+                projectId, request != null && request.isIncludeFinancialData());
+
+        AiPmfDiagnoseResponse response = pmfService.diagnosePmfWithAi(projectId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 저장된 AI PMF 진단 결과 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @return AI PMF 진단 결과 (없으면 404)
+     */
+    @GetMapping("/projects/{projectId}/pmf/ai-diagnose")
+    @Operation(
+            summary = "AI PMF 진단 결과 조회",
+            description = "저장된 AI PMF 진단 결과를 조회합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = AiPmfDiagnoseResponse.class))),
+            @ApiResponse(responseCode = "404", description = "진단 결과 없음")
+    })
+    public ResponseEntity<AiPmfDiagnoseResponse> getAiDiagnoseResult(
+            @Parameter(description = "프로젝트 ID") @PathVariable String projectId
+    ) {
+        log.info("GET /projects/{}/pmf/ai-diagnose", projectId);
+
+        return pmfService.getAiDiagnoseResult(projectId)
+                .map(result -> {
+                    log.info("AI PMF 진단 결과 조회 완료 - projectId={}, score={}", projectId, result.overallScore());
+                    return ResponseEntity.ok(result);
+                })
+                .orElseGet(() -> {
+                    log.info("AI PMF 진단 결과 없음 - projectId={}", projectId);
                     return ResponseEntity.notFound().build();
                 });
     }

--- a/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/PmfService.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/domain/service/PmfService.java
@@ -1,11 +1,24 @@
 package com.vibe.bizplan.bizplan_be.domain.service;
 
+import com.vibe.bizplan.bizplan_be.domain.entity.BizPlanSection;
+import com.vibe.bizplan.bizplan_be.domain.entity.Project;
+import com.vibe.bizplan.bizplan_be.domain.exception.ProjectNotFoundException;
+import com.vibe.bizplan.bizplan_be.domain.service.util.JsonParsingUtil;
+import com.vibe.bizplan.bizplan_be.dto.request.AiPmfDiagnoseRequest;
 import com.vibe.bizplan.bizplan_be.dto.request.PmfSubmitRequest;
+import com.vibe.bizplan.bizplan_be.dto.response.AiPmfDiagnoseResponse;
 import com.vibe.bizplan.bizplan_be.dto.response.PmfQuestionResponse;
 import com.vibe.bizplan.bizplan_be.dto.response.PmfQuestionResponse.QuestionOption;
 import com.vibe.bizplan.bizplan_be.dto.response.PmfQuestionsResponse;
 import com.vibe.bizplan.bizplan_be.dto.response.PmfReportResponse;
 import com.vibe.bizplan.bizplan_be.dto.response.PmfReportResponse.*;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.AiEngineClient;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.PmfDiagnoseRequest;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.PmfDiagnoseResponse;
+import com.vibe.bizplan.bizplan_be.infrastructure.repository.BizPlanSectionRepository;
+import com.vibe.bizplan.bizplan_be.infrastructure.repository.FinancialDataRepository;
+import com.vibe.bizplan.bizplan_be.infrastructure.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -20,10 +33,19 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class PmfService {
+
+    private final ProjectRepository projectRepository;
+    private final BizPlanSectionRepository sectionRepository;
+    private final FinancialDataRepository financialDataRepository;
+    private final AiEngineClient aiEngineClient;
+    private final JsonParsingUtil jsonParsingUtil;
 
     // MVP: 인메모리 저장소 (프로젝트ID -> PMF 리포트)
     private final Map<String, PmfReportResponse> reportStore = new ConcurrentHashMap<>();
+    // AI PMF 진단 결과 저장소
+    private final Map<String, AiPmfDiagnoseResponse> aiDiagnoseStore = new ConcurrentHashMap<>();
 
     /**
      * PMF 설문 질문 목록 조회.
@@ -159,6 +181,87 @@ public class PmfService {
     public Optional<PmfReportResponse> getReport(String projectId) {
         log.info("[PMF] 리포트 조회 - projectId={}", projectId);
         return Optional.ofNullable(reportStore.get(projectId));
+    }
+
+    /**
+     * AI 기반 PMF 진단.
+     * 사업계획서 내용과 재무 데이터를 분석하여 PMF를 진단한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param request 진단 요청
+     * @return AI PMF 진단 결과
+     */
+    public AiPmfDiagnoseResponse diagnosePmfWithAi(String projectId, AiPmfDiagnoseRequest request) {
+        Objects.requireNonNull(projectId, "프로젝트 ID는 필수입니다");
+        long startTime = System.currentTimeMillis();
+        log.info("[PMF] AI 진단 시작 - projectId={}, includeFinancialData={}",
+                projectId, request != null && request.isIncludeFinancialData());
+
+        // 프로젝트 조회
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> {
+                    log.error("[PMF] 프로젝트 조회 실패 - projectId={}", projectId);
+                    return new ProjectNotFoundException(projectId);
+                });
+
+        String templateCode = project.getTemplateCode().name();
+
+        // Wizard 답변 파싱
+        Map<String, Object> context = jsonParsingUtil.parseToImmutableMap(project.getWizardAnswers());
+
+        // 사업계획서 섹션 내용 조회
+        Map<String, String> businessPlanContent = new LinkedHashMap<>();
+        List<BizPlanSection> sections = sectionRepository.findByProjectIdOrderBySectionType(projectId);
+        for (BizPlanSection section : sections) {
+            if (section.getContent() != null && !section.getContent().isBlank()) {
+                businessPlanContent.put(section.getSectionType(), section.getContent());
+            }
+        }
+        log.debug("[PMF] 사업계획서 섹션 조회 완료 - count={}", businessPlanContent.size());
+
+        // 재무 데이터 조회 (선택)
+        Map<String, Object> financialData = null;
+        if (request != null && request.isIncludeFinancialData()) {
+            financialData = financialDataRepository.findByProjectId(projectId)
+                    .map(fd -> {
+                        Map<String, Object> data = new LinkedHashMap<>();
+                        data.put("assumptions", jsonParsingUtil.parseToImmutableMap(fd.getAssumptions()));
+                        data.put("projections", jsonParsingUtil.parseToImmutableMap(fd.getProjectionResult()));
+                        return data;
+                    })
+                    .orElse(null);
+            log.debug("[PMF] 재무 데이터 조회 완료 - found={}", financialData != null);
+        }
+
+        // AI Engine 요청 생성
+        PmfDiagnoseRequest aiRequest = financialData != null
+                ? PmfDiagnoseRequest.withFinancialData(projectId, templateCode, businessPlanContent, context, financialData)
+                : PmfDiagnoseRequest.of(projectId, templateCode, businessPlanContent, context);
+
+        // AI Engine 호출
+        log.debug("[PMF] AI 엔진 호출 중 - projectId={}", projectId);
+        PmfDiagnoseResponse aiResponse = aiEngineClient.diagnosePmf(aiRequest);
+
+        // 결과 변환 및 저장
+        AiPmfDiagnoseResponse response = AiPmfDiagnoseResponse.from(aiResponse);
+        aiDiagnoseStore.put(projectId, response);
+
+        long duration = System.currentTimeMillis() - startTime;
+        log.info("[PMF] AI 진단 완료 - projectId={}, score={}, grade={}, duration={}ms",
+                projectId, response.overallScore(), response.scoreGrade(), duration);
+
+        return response;
+    }
+
+    /**
+     * 저장된 AI PMF 진단 결과 조회.
+     *
+     * @param projectId 프로젝트 ID
+     * @return AI PMF 진단 결과 (Optional)
+     */
+    public Optional<AiPmfDiagnoseResponse> getAiDiagnoseResult(String projectId) {
+        log.info("[PMF] AI 진단 결과 조회 - projectId={}", projectId);
+        return Optional.ofNullable(aiDiagnoseStore.get(projectId));
     }
 
     /**

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/AiPmfDiagnoseRequest.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/request/AiPmfDiagnoseRequest.java
@@ -1,0 +1,23 @@
+package com.vibe.bizplan.bizplan_be.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * AI PMF 진단 요청 DTO.
+ * 클라이언트에서 AI 기반 PMF 진단을 요청할 때 사용.
+ */
+@Schema(description = "AI PMF 진단 요청")
+public record AiPmfDiagnoseRequest(
+
+        /** 재무 데이터 포함 여부 (기본값: true) */
+        @Schema(description = "재무 데이터 포함 여부", example = "true", defaultValue = "true")
+        Boolean includeFinancialData
+) {
+    /**
+     * 기본값 적용 메서드.
+     */
+    public boolean isIncludeFinancialData() {
+        return includeFinancialData == null || includeFinancialData;
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/AiPmfDiagnoseResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/AiPmfDiagnoseResponse.java
@@ -1,0 +1,125 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.PmfDiagnoseResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AI PMF 진단 응답 DTO.
+ */
+@Schema(description = "AI PMF 진단 응답")
+public record AiPmfDiagnoseResponse(
+
+        /** 프로젝트 ID */
+        @Schema(description = "프로젝트 ID")
+        String projectId,
+
+        /** 종합 점수 (0-100) */
+        @Schema(description = "종합 점수 (0-100)", example = "75")
+        int overallScore,
+
+        /** 점수 등급 */
+        @Schema(description = "점수 등급", example = "good",
+                allowableValues = {"excellent", "good", "fair", "poor", "critical"})
+        String scoreGrade,
+
+        /** 카테고리별 점수 */
+        @Schema(description = "카테고리별 점수")
+        Map<String, Integer> categoryScores,
+
+        /** 식별된 리스크 목록 */
+        @Schema(description = "식별된 리스크 목록")
+        List<RiskItem> risks,
+
+        /** 강점 목록 */
+        @Schema(description = "강점 목록")
+        List<String> strengths,
+
+        /** 종합 분석 요약 */
+        @Schema(description = "종합 분석 요약")
+        String summary,
+
+        /** 우선 조치 사항 목록 */
+        @Schema(description = "우선 조치 사항 목록")
+        List<String> priorityActions,
+
+        /** 사용된 AI 모델 */
+        @Schema(description = "사용된 AI 모델", example = "gemini-1.5-pro")
+        String modelUsed,
+
+        /** 분석 소요 시간 (ms) */
+        @Schema(description = "분석 소요 시간 (ms)", example = "3500")
+        int analysisTimeMs,
+
+        /** 분석 일시 */
+        @Schema(description = "분석 일시")
+        LocalDateTime analyzedAt
+) {
+
+    /**
+     * 리스크 항목 DTO.
+     */
+    @Schema(description = "리스크 항목")
+    public record RiskItem(
+            /** 카테고리 */
+            @Schema(description = "카테고리", example = "market")
+            String category,
+
+            /** 리스크 제목 */
+            @Schema(description = "리스크 제목", example = "시장 규모 불확실")
+            String title,
+
+            /** 리스크 설명 */
+            @Schema(description = "리스크 설명")
+            String description,
+
+            /** 위험 수준 */
+            @Schema(description = "위험 수준", example = "medium",
+                    allowableValues = {"high", "medium", "low"})
+            String level,
+
+            /** 추천 조치 */
+            @Schema(description = "추천 조치")
+            String recommendation,
+
+            /** 관련 섹션 */
+            @Schema(description = "관련 섹션")
+            List<String> relatedSections
+    ) {}
+
+    /**
+     * AI Engine 응답으로부터 생성.
+     */
+    public static AiPmfDiagnoseResponse from(PmfDiagnoseResponse aiResponse) {
+        List<RiskItem> risks = aiResponse.risks() != null
+                ? aiResponse.risks().stream()
+                        .map(r -> new RiskItem(
+                                r.category(),
+                                r.title(),
+                                r.description(),
+                                r.level(),
+                                r.recommendation(),
+                                r.relatedSections()
+                        ))
+                        .toList()
+                : List.of();
+
+        return new AiPmfDiagnoseResponse(
+                aiResponse.projectId(),
+                aiResponse.overallScore(),
+                aiResponse.scoreGrade(),
+                aiResponse.categoryScores(),
+                risks,
+                aiResponse.strengths() != null ? aiResponse.strengths() : List.of(),
+                aiResponse.summary(),
+                aiResponse.priorityActions() != null ? aiResponse.priorityActions() : List.of(),
+                aiResponse.modelUsed(),
+                aiResponse.analysisTimeMs(),
+                LocalDateTime.now()
+        );
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/AiEngineClient.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/AiEngineClient.java
@@ -2,6 +2,8 @@ package com.vibe.bizplan.bizplan_be.infrastructure.client;
 
 import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.BizPlanGenerateRequest;
 import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.BizPlanGenerateResponse;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.PmfDiagnoseRequest;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.PmfDiagnoseResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -70,6 +72,39 @@ public class AiEngineClient {
             log.error("AI 엔진 호출 실패: projectId={}, section={}, error={}",
                     request.projectId(), request.sectionType(), e.getMessage());
             throw new AiEngineException("AI 엔진 호출에 실패했습니다: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * PMF AI 진단 요청.
+     *
+     * @param request 진단 요청
+     * @return 진단 응답
+     * @throws AiEngineException AI 엔진 호출 실패 시
+     */
+    public PmfDiagnoseResponse diagnosePmf(PmfDiagnoseRequest request) {
+        log.info("AI 엔진 PMF 진단 요청: projectId={}", request.projectId());
+        
+        try {
+            @SuppressWarnings("null")
+            PmfDiagnoseResponse response = restClient.post()
+                    .uri("/api/v1/pmf/diagnose")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .body(PmfDiagnoseResponse.class);
+            
+            log.info("AI 엔진 PMF 진단 완료: projectId={}, score={}, grade={}",
+                    request.projectId(),
+                    response != null ? response.overallScore() : 0,
+                    response != null ? response.scoreGrade() : "unknown");
+            
+            return response;
+            
+        } catch (RestClientException e) {
+            log.error("AI 엔진 PMF 진단 실패: projectId={}, error={}",
+                    request.projectId(), e.getMessage());
+            throw new AiEngineException("AI 엔진 PMF 진단에 실패했습니다: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/dto/PmfDiagnoseRequest.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/dto/PmfDiagnoseRequest.java
@@ -1,0 +1,75 @@
+package com.vibe.bizplan.bizplan_be.infrastructure.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * AI Engine PMF 진단 요청 DTO.
+ */
+public record PmfDiagnoseRequest(
+
+        /** 프로젝트 ID */
+        @JsonProperty("project_id")
+        String projectId,
+
+        /** 템플릿 코드 */
+        @JsonProperty("template_code")
+        String templateCode,
+
+        /** 사업계획서 내용 (섹션별) */
+        @JsonProperty("business_plan_content")
+        Map<String, String> businessPlanContent,
+
+        /** 재무 데이터 포함 여부 */
+        @JsonProperty("include_financial_data")
+        boolean includeFinancialData,
+
+        /** 재무 데이터 (선택) */
+        @JsonProperty("financial_data")
+        Map<String, Object> financialData,
+
+        /** Wizard 답변 컨텍스트 */
+        Map<String, Object> context
+) {
+
+    /**
+     * 간단 생성용 팩토리 메서드.
+     */
+    public static PmfDiagnoseRequest of(
+            String projectId,
+            String templateCode,
+            Map<String, String> businessPlanContent,
+            Map<String, Object> context
+    ) {
+        return new PmfDiagnoseRequest(
+                projectId,
+                templateCode,
+                businessPlanContent,
+                false,
+                null,
+                context
+        );
+    }
+
+    /**
+     * 재무 데이터 포함 생성용 팩토리 메서드.
+     */
+    public static PmfDiagnoseRequest withFinancialData(
+            String projectId,
+            String templateCode,
+            Map<String, String> businessPlanContent,
+            Map<String, Object> context,
+            Map<String, Object> financialData
+    ) {
+        return new PmfDiagnoseRequest(
+                projectId,
+                templateCode,
+                businessPlanContent,
+                true,
+                financialData,
+                context
+        );
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/dto/PmfDiagnoseResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/dto/PmfDiagnoseResponse.java
@@ -1,0 +1,75 @@
+package com.vibe.bizplan.bizplan_be.infrastructure.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AI Engine PMF 진단 응답 DTO.
+ */
+public record PmfDiagnoseResponse(
+
+        /** 프로젝트 ID */
+        @JsonProperty("project_id")
+        String projectId,
+
+        /** 종합 점수 (0-100) */
+        @JsonProperty("overall_score")
+        int overallScore,
+
+        /** 점수 등급 (excellent, good, fair, poor, critical) */
+        @JsonProperty("score_grade")
+        String scoreGrade,
+
+        /** 카테고리별 점수 */
+        @JsonProperty("category_scores")
+        Map<String, Integer> categoryScores,
+
+        /** 식별된 리스크 목록 */
+        List<PmfRisk> risks,
+
+        /** 강점 목록 */
+        List<String> strengths,
+
+        /** 종합 분석 요약 */
+        String summary,
+
+        /** 우선 조치 사항 목록 */
+        @JsonProperty("priority_actions")
+        List<String> priorityActions,
+
+        /** 사용된 AI 모델 */
+        @JsonProperty("model_used")
+        String modelUsed,
+
+        /** 분석 소요 시간 (ms) */
+        @JsonProperty("analysis_time_ms")
+        int analysisTimeMs
+) {
+
+    /**
+     * PMF 리스크 정보.
+     */
+    public record PmfRisk(
+            /** 카테고리 */
+            String category,
+
+            /** 리스크 제목 */
+            String title,
+
+            /** 리스크 설명 */
+            String description,
+
+            /** 위험 수준 (high, medium, low) */
+            String level,
+
+            /** 추천 조치 */
+            String recommendation,
+
+            /** 관련 섹션 */
+            @JsonProperty("related_sections")
+            List<String> relatedSections
+    ) {}
+}
+


### PR DESCRIPTION
## 개요
AI Engine의 PMF 진단 API를 연동하여 사업계획서와 재무 데이터를 AI로 분석하는 기능을 구현합니다.

## 변경 내용
- `AiEngineClient.diagnosePmf()`: AI 엔진 PMF 진단 메서드 추가
- `PmfDiagnoseRequest/Response` DTO 생성 (AI Engine 연동용)
- `AiPmfDiagnoseRequest/Response` DTO 생성 (클라이언트 응답용)
- `PmfService.diagnosePmfWithAi()`: AI 진단 로직 구현
- `PmfController`: AI 진단 엔드포인트 추가

## API 엔드포인트
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/projects/{projectId}/pmf/ai-diagnose` | AI PMF 진단 실행 |
| GET | `/projects/{projectId}/pmf/ai-diagnose` | AI PMF 진단 결과 조회 |

## 응답 예시
```json
{
  "projectId": "...",
  "overallScore": 75,
  "scoreGrade": "good",
  "categoryScores": { "market_fit": 80, "problem_solution": 70 },
  "risks": [...],
  "strengths": [...],
  "summary": "종합 분석...",
  "priorityActions": [...]
}
```

## 테스트
- 컴파일 성공 확인

Closes #64