### PR TITLE
[BE-AI-004] AI Engine 보조 API 연동

### DIFF
--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/BizPlanMetaController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/BizPlanMetaController.java
@@ -1,0 +1,58 @@
+package com.vibe.bizplan.bizplan_be.api;
+
+import com.vibe.bizplan.bizplan_be.dto.response.SectionTypesListResponse;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.AiEngineClient;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.SectionTypesResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 사업계획서 메타데이터 REST API 컨트롤러.
+ * 섹션 타입 목록 등 정적 메타데이터를 제공한다.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/bizplan")
+@RequiredArgsConstructor
+@Tag(name = "BizPlan Metadata", description = "사업계획서 메타데이터 API")
+public class BizPlanMetaController {
+
+    private final AiEngineClient aiEngineClient;
+
+    /**
+     * 사업계획서 섹션 타입 목록 조회.
+     *
+     * @return 섹션 타입 목록
+     */
+    @GetMapping("/section-types")
+    @Operation(
+            summary = "섹션 타입 목록 조회",
+            description = "사업계획서에서 지원하는 모든 섹션 타입 목록을 조회합니다. " +
+                    "각 섹션의 타입 코드, 이름, 설명을 제공합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = SectionTypesListResponse.class))),
+            @ApiResponse(responseCode = "500", description = "AI 엔진 오류")
+    })
+    public ResponseEntity<SectionTypesListResponse> getSectionTypes() {
+        log.info("GET /bizplan/section-types");
+
+        SectionTypesResponse aiResponse = aiEngineClient.getSectionTypes();
+        SectionTypesListResponse response = SectionTypesListResponse.from(aiResponse);
+
+        log.info("섹션 타입 목록 조회 완료: count={}", response.sectionTypes().size());
+        return ResponseEntity.ok(response);
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/api/PmfController.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/api/PmfController.java
@@ -4,8 +4,11 @@ import com.vibe.bizplan.bizplan_be.domain.service.PmfService;
 import com.vibe.bizplan.bizplan_be.dto.request.AiPmfDiagnoseRequest;
 import com.vibe.bizplan.bizplan_be.dto.request.PmfSubmitRequest;
 import com.vibe.bizplan.bizplan_be.dto.response.AiPmfDiagnoseResponse;
+import com.vibe.bizplan.bizplan_be.dto.response.PmfCriteriaListResponse;
 import com.vibe.bizplan.bizplan_be.dto.response.PmfQuestionsResponse;
 import com.vibe.bizplan.bizplan_be.dto.response.PmfReportResponse;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.AiEngineClient;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.PmfCriteriaResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -31,6 +34,7 @@ import org.springframework.web.bind.annotation.*;
 public class PmfController {
 
     private final PmfService pmfService;
+    private final AiEngineClient aiEngineClient;
 
     /**
      * PMF 설문 질문 목록 조회.
@@ -166,6 +170,32 @@ public class PmfController {
                     log.info("AI PMF 진단 결과 없음 - projectId={}", projectId);
                     return ResponseEntity.notFound().build();
                 });
+    }
+
+    /**
+     * PMF 평가 기준 조회.
+     * AI Engine에서 PMF 진단에 사용되는 평가 기준 목록을 조회합니다.
+     *
+     * @return PMF 평가 기준 목록
+     */
+    @GetMapping("/pmf/criteria")
+    @Operation(
+            summary = "PMF 평가 기준 조회",
+            description = "PMF 진단에 사용되는 평가 기준(카테고리, 가중치 등) 목록을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = PmfCriteriaListResponse.class))),
+            @ApiResponse(responseCode = "500", description = "AI 엔진 오류")
+    })
+    public ResponseEntity<PmfCriteriaListResponse> getPmfCriteria() {
+        log.info("GET /pmf/criteria");
+
+        PmfCriteriaResponse aiResponse = aiEngineClient.getPmfCriteria();
+        PmfCriteriaListResponse response = PmfCriteriaListResponse.from(aiResponse);
+
+        log.info("PMF 평가 기준 조회 완료: count={}", response.criteria().size());
+        return ResponseEntity.ok(response);
     }
 }
 

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/PmfCriteriaListResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/PmfCriteriaListResponse.java
@@ -1,0 +1,54 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.PmfCriteriaResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * PMF 평가 기준 목록 응답 DTO.
+ */
+@Schema(description = "PMF 평가 기준 목록 응답")
+public record PmfCriteriaListResponse(
+
+        /** 평가 기준 목록 */
+        @Schema(description = "평가 기준 목록")
+        List<CriteriaItem> criteria
+) {
+
+    /**
+     * 평가 기준 항목.
+     */
+    @Schema(description = "평가 기준 항목")
+    public record CriteriaItem(
+            /** 카테고리 코드 */
+            @Schema(description = "카테고리 코드", example = "market_fit")
+            String category,
+
+            /** 기준 이름 */
+            @Schema(description = "기준 이름", example = "시장 적합성")
+            String name,
+
+            /** 가중치 (0.0 ~ 1.0) */
+            @Schema(description = "가중치 (0.0 ~ 1.0)", example = "0.3")
+            Double weight,
+
+            /** 설명 */
+            @Schema(description = "설명", example = "목표 시장에 대한 적합성 평가")
+            String description
+    ) {}
+
+    /**
+     * AI Engine 응답으로부터 생성.
+     */
+    public static PmfCriteriaListResponse from(PmfCriteriaResponse aiResponse) {
+        List<CriteriaItem> items = aiResponse != null && aiResponse.criteria() != null
+                ? aiResponse.criteria().stream()
+                        .map(c -> new CriteriaItem(c.category(), c.name(), c.weight(), c.description()))
+                        .toList()
+                : List.of();
+
+        return new PmfCriteriaListResponse(items);
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/SectionTypesListResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/dto/response/SectionTypesListResponse.java
@@ -1,0 +1,50 @@
+package com.vibe.bizplan.bizplan_be.dto.response;
+
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.SectionTypesResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * 사업계획서 섹션 타입 목록 응답 DTO.
+ */
+@Schema(description = "사업계획서 섹션 타입 목록 응답")
+public record SectionTypesListResponse(
+
+        /** 섹션 타입 목록 */
+        @Schema(description = "섹션 타입 목록")
+        List<SectionTypeItem> sectionTypes
+) {
+
+    /**
+     * 섹션 타입 항목.
+     */
+    @Schema(description = "섹션 타입 항목")
+    public record SectionTypeItem(
+            /** 섹션 타입 코드 */
+            @Schema(description = "섹션 타입 코드", example = "executive_summary")
+            String type,
+
+            /** 섹션 이름 */
+            @Schema(description = "섹션 이름", example = "사업개요")
+            String name,
+
+            /** 섹션 설명 */
+            @Schema(description = "섹션 설명", example = "사업의 핵심 내용을 요약합니다.")
+            String description
+    ) {}
+
+    /**
+     * AI Engine 응답으로부터 생성.
+     */
+    public static SectionTypesListResponse from(SectionTypesResponse aiResponse) {
+        List<SectionTypeItem> items = aiResponse != null && aiResponse.sectionTypes() != null
+                ? aiResponse.sectionTypes().stream()
+                        .map(s -> new SectionTypeItem(s.type(), s.name(), s.description()))
+                        .toList()
+                : List.of();
+
+        return new SectionTypesListResponse(items);
+    }
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/AiEngineClient.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/AiEngineClient.java
@@ -2,8 +2,10 @@ package com.vibe.bizplan.bizplan_be.infrastructure.client;
 
 import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.BizPlanGenerateRequest;
 import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.BizPlanGenerateResponse;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.PmfCriteriaResponse;
 import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.PmfDiagnoseRequest;
 import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.PmfDiagnoseResponse;
+import com.vibe.bizplan.bizplan_be.infrastructure.client.dto.SectionTypesResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -105,6 +107,60 @@ public class AiEngineClient {
             log.error("AI 엔진 PMF 진단 실패: projectId={}, error={}",
                     request.projectId(), e.getMessage());
             throw new AiEngineException("AI 엔진 PMF 진단에 실패했습니다: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 사업계획서 섹션 타입 목록 조회.
+     *
+     * @return 섹션 타입 목록
+     * @throws AiEngineException AI 엔진 호출 실패 시
+     */
+    public SectionTypesResponse getSectionTypes() {
+        log.info("AI 엔진 섹션 타입 목록 조회");
+        
+        try {
+            @SuppressWarnings("null")
+            SectionTypesResponse response = restClient.get()
+                    .uri("/api/v1/bizplan/sections")
+                    .retrieve()
+                    .body(SectionTypesResponse.class);
+            
+            log.info("AI 엔진 섹션 타입 목록 조회 완료: count={}",
+                    response != null && response.sectionTypes() != null ? response.sectionTypes().size() : 0);
+            
+            return response;
+            
+        } catch (RestClientException e) {
+            log.error("AI 엔진 섹션 타입 목록 조회 실패: error={}", e.getMessage());
+            throw new AiEngineException("AI 엔진 섹션 타입 목록 조회에 실패했습니다: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * PMF 평가 기준 목록 조회.
+     *
+     * @return PMF 평가 기준 목록
+     * @throws AiEngineException AI 엔진 호출 실패 시
+     */
+    public PmfCriteriaResponse getPmfCriteria() {
+        log.info("AI 엔진 PMF 평가 기준 조회");
+        
+        try {
+            @SuppressWarnings("null")
+            PmfCriteriaResponse response = restClient.get()
+                    .uri("/api/v1/pmf/criteria")
+                    .retrieve()
+                    .body(PmfCriteriaResponse.class);
+            
+            log.info("AI 엔진 PMF 평가 기준 조회 완료: count={}",
+                    response != null && response.criteria() != null ? response.criteria().size() : 0);
+            
+            return response;
+            
+        } catch (RestClientException e) {
+            log.error("AI 엔진 PMF 평가 기준 조회 실패: error={}", e.getMessage());
+            throw new AiEngineException("AI 엔진 PMF 평가 기준 조회에 실패했습니다: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/dto/PmfCriteriaResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/dto/PmfCriteriaResponse.java
@@ -1,0 +1,26 @@
+package com.vibe.bizplan.bizplan_be.infrastructure.client.dto;
+
+import java.util.List;
+
+/**
+ * AI Engine PMF 평가 기준 응답 DTO.
+ */
+public record PmfCriteriaResponse(
+        /** 평가 기준 목록 */
+        List<CriteriaItem> criteria
+) {
+    /**
+     * 평가 기준 항목.
+     */
+    public record CriteriaItem(
+            /** 카테고리 코드 */
+            String category,
+            /** 기준 이름 */
+            String name,
+            /** 가중치 (0.0 ~ 1.0) */
+            Double weight,
+            /** 설명 */
+            String description
+    ) {}
+}
+

--- a/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/dto/SectionTypesResponse.java
+++ b/src/main/java/com/vibe/bizplan/bizplan_be/infrastructure/client/dto/SectionTypesResponse.java
@@ -1,0 +1,27 @@
+package com.vibe.bizplan.bizplan_be.infrastructure.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * AI Engine 섹션 타입 목록 응답 DTO.
+ */
+public record SectionTypesResponse(
+        /** 섹션 타입 목록 */
+        @JsonProperty("section_types")
+        List<SectionTypeInfo> sectionTypes
+) {
+    /**
+     * 섹션 타입 정보.
+     */
+    public record SectionTypeInfo(
+            /** 섹션 타입 코드 */
+            String type,
+            /** 섹션 이름 */
+            String name,
+            /** 섹션 설명 */
+            String description
+    ) {}
+}
+


### PR DESCRIPTION
## 개요
AI Engine의 보조 API (섹션 타입 목록, PMF 평가 기준)를 연동합니다.

## 변경 내용
- `AiEngineClient`: 보조 API 메서드 추가
  - `getSectionTypes()`: 섹션 타입 목록 조회
  - `getPmfCriteria()`: PMF 평가 기준 조회
- `SectionTypesResponse/PmfCriteriaResponse` DTO 생성
- `SectionTypesListResponse/PmfCriteriaListResponse` DTO 생성
- `BizPlanMetaController`: 섹션 타입 목록 API 추가
- `PmfController`: PMF 평가 기준 API 추가

## API 엔드포인트
| Method | Endpoint | 설명 |
|--------|----------|------|
| GET | `/bizplan/section-types` | 사업계획서 섹션 타입 목록 |
| GET | `/pmf/criteria` | PMF 평가 기준 목록 |

## 테스트
- 컴파일 성공 확인

Closes #65